### PR TITLE
refactor: pass `Vec<SpanRecord>` to `Reporter::report()` instead of `&[SpanRecord]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Upgrade dependencies including opentelemtry and more.
 - Remove deprecated methods `Config::batch_report_interval` and `Config::batch_report_max_spans`.
 - Deprecate `full_name!()` and rename it to `full_path!()`.
+- Pass `Vec<SpanRecord>` to `Reporter::report()` instead of `&[SpanRecord]`.
 
 ## v0.6.8
 

--- a/fastrace-datadog/src/lib.rs
+++ b/fastrace-datadog/src/lib.rs
@@ -67,8 +67,8 @@ impl DatadogReporter {
         Ok(buf)
     }
 
-    fn try_report(&self, spans: &[SpanRecord]) -> Result<(), Box<dyn std::error::Error>> {
-        let datadog_spans = self.convert(spans);
+    fn try_report(&self, spans: Vec<SpanRecord>) -> Result<(), Box<dyn std::error::Error>> {
+        let datadog_spans = self.convert(&spans);
         let bytes = self.serialize(datadog_spans)?;
         let client = reqwest::blocking::Client::new();
         let _rep = client
@@ -82,7 +82,7 @@ impl DatadogReporter {
 }
 
 impl Reporter for DatadogReporter {
-    fn report(&mut self, spans: &[SpanRecord]) {
+    fn report(&mut self, spans: Vec<SpanRecord>) {
         if spans.is_empty() {
             return;
         }

--- a/fastrace-jaeger/src/lib.rs
+++ b/fastrace-jaeger/src/lib.rs
@@ -133,12 +133,12 @@ impl JaegerReporter {
 }
 
 impl Reporter for JaegerReporter {
-    fn report(&mut self, spans: &[SpanRecord]) {
+    fn report(&mut self, spans: Vec<SpanRecord>) {
         if spans.is_empty() {
             return;
         }
 
-        if let Err(err) = self.try_report(spans) {
+        if let Err(err) = self.try_report(&spans) {
             log::error!("report to jaeger failed: {}", err);
         }
     }

--- a/fastrace/benches/compare.rs
+++ b/fastrace/benches/compare.rs
@@ -18,7 +18,7 @@ fn init_fastrace() {
     struct DummyReporter;
 
     impl fastrace::collector::Reporter for DummyReporter {
-        fn report(&mut self, _spans: &[fastrace::prelude::SpanRecord]) {}
+        fn report(&mut self, _spans: Vec<fastrace::prelude::SpanRecord>) {}
     }
 
     fastrace::set_reporter(DummyReporter, fastrace::collector::Config::default());

--- a/fastrace/benches/trace.rs
+++ b/fastrace/benches/trace.rs
@@ -11,7 +11,7 @@ fn init_fastrace() {
     struct DummyReporter;
 
     impl fastrace::collector::Reporter for DummyReporter {
-        fn report(&mut self, _spans: &[fastrace::prelude::SpanRecord]) {}
+        fn report(&mut self, _spans: Vec<fastrace::prelude::SpanRecord>) {}
     }
 
     fastrace::set_reporter(DummyReporter, fastrace::collector::Config::default());

--- a/fastrace/examples/asynchronous.rs
+++ b/fastrace/examples/asynchronous.rs
@@ -108,9 +108,9 @@ impl ReportAll {
 }
 
 impl Reporter for ReportAll {
-    fn report(&mut self, spans: &[SpanRecord]) {
-        self.jaeger.report(spans);
-        self.datadog.report(spans);
+    fn report(&mut self, spans: Vec<SpanRecord>) {
+        self.jaeger.report(spans.clone());
+        self.datadog.report(spans.clone());
         self.opentelemetry.report(spans);
     }
 }

--- a/fastrace/examples/synchronous.rs
+++ b/fastrace/examples/synchronous.rs
@@ -84,9 +84,9 @@ impl ReportAll {
 }
 
 impl Reporter for ReportAll {
-    fn report(&mut self, spans: &[SpanRecord]) {
-        self.jaeger.report(spans);
-        self.datadog.report(spans);
+    fn report(&mut self, spans: Vec<SpanRecord>) {
+        self.jaeger.report(spans.clone());
+        self.datadog.report(spans.clone());
         self.opentelemetry.report(spans);
     }
 }

--- a/fastrace/src/collector/console_reporter.rs
+++ b/fastrace/src/collector/console_reporter.rs
@@ -7,7 +7,7 @@ use crate::collector::SpanRecord;
 pub struct ConsoleReporter;
 
 impl Reporter for ConsoleReporter {
-    fn report(&mut self, spans: &[SpanRecord]) {
+    fn report(&mut self, spans: Vec<SpanRecord>) {
         for span in spans {
             eprintln!("{:#?}", span);
         }

--- a/fastrace/src/collector/global_collector.rs
+++ b/fastrace/src/collector/global_collector.rs
@@ -116,7 +116,7 @@ pub fn flush() {
 /// further processing and analysis.
 pub trait Reporter: Send + 'static {
     /// Reports a batch of spans to a remote service.
-    fn report(&mut self, spans: &[SpanRecord]);
+    fn report(&mut self, spans: Vec<SpanRecord>);
 }
 
 #[derive(Default, Clone)]
@@ -373,8 +373,10 @@ impl GlobalCollector {
             }
         }
 
-        self.reporter.as_mut().unwrap().report(committed_records);
-        committed_records.clear();
+        self.reporter
+            .as_mut()
+            .unwrap()
+            .report(std::mem::take(committed_records));
     }
 }
 

--- a/fastrace/src/collector/global_collector.rs
+++ b/fastrace/src/collector/global_collector.rs
@@ -206,7 +206,6 @@ pub(crate) struct GlobalCollector {
     drop_collects: Vec<DropCollect>,
     commit_collects: Vec<CommitCollect>,
     submit_spans: Vec<SubmitSpans>,
-    committed_records: Vec<SpanRecord>,
 }
 
 impl GlobalCollector {
@@ -216,7 +215,6 @@ impl GlobalCollector {
             reporter: Some(Box::new(reporter)),
 
             active_collectors: HashMap::new(),
-            committed_records: Vec::new(),
 
             start_collects: Vec::new(),
             drop_collects: Vec::new(),
@@ -252,13 +250,11 @@ impl GlobalCollector {
         debug_assert!(self.drop_collects.is_empty());
         debug_assert!(self.commit_collects.is_empty());
         debug_assert!(self.submit_spans.is_empty());
-        debug_assert!(self.committed_records.is_empty());
 
         let start_collects = &mut self.start_collects;
         let drop_collects = &mut self.drop_collects;
         let commit_collects = &mut self.commit_collects;
         let submit_spans = &mut self.submit_spans;
-        let committed_records = &mut self.committed_records;
 
         {
             SPSC_RXS.lock().retain_mut(|rx| {
@@ -350,13 +346,14 @@ impl GlobalCollector {
         }
 
         let anchor = Anchor::new();
+        let mut committed_records = Vec::new();
 
         for CommitCollect { collect_id } in commit_collects.drain(..) {
             if let Some(mut active_collector) = self.active_collectors.remove(&collect_id) {
                 postprocess_span_collection(
                     active_collector.span_collections,
                     &anchor,
-                    committed_records,
+                    &mut committed_records,
                     &mut active_collector.dangling_events,
                 );
             }
@@ -367,16 +364,13 @@ impl GlobalCollector {
                 postprocess_span_collection(
                     active_collector.span_collections.drain(..),
                     &anchor,
-                    committed_records,
+                    &mut committed_records,
                     &mut active_collector.dangling_events,
                 );
             }
         }
 
-        self.reporter
-            .as_mut()
-            .unwrap()
-            .report(std::mem::take(committed_records));
+        self.reporter.as_mut().unwrap().report(committed_records);
     }
 }
 

--- a/fastrace/src/collector/test_reporter.rs
+++ b/fastrace/src/collector/test_reporter.rs
@@ -24,7 +24,7 @@ impl TestReporter {
 }
 
 impl Reporter for TestReporter {
-    fn report(&mut self, spans: &[SpanRecord]) {
-        self.spans.lock().extend_from_slice(spans);
+    fn report(&mut self, mut spans: Vec<SpanRecord>) {
+        self.spans.lock().append(&mut spans);
     }
 }


### PR DESCRIPTION
Closes https://github.com/fast/fastrace/issues/24