### PR TITLE
feat: add SpanContext::sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Remove deprecated methods `Config::batch_report_interval` and `Config::batch_report_max_spans`.
 - Deprecate `full_name!()` and rename it to `full_path!()`.
 - Pass `Vec<SpanRecord>` to `Reporter::report()` instead of `&[SpanRecord]`.
+- Removed `SpanContext::encode_w3c_traceparent_with_sampled()`.
+- Added `SpanContext.sampled`, which be propagated to the child span.
 
 ## v0.6.8
 

--- a/fastrace/src/collector/mod.rs
+++ b/fastrace/src/collector/mod.rs
@@ -70,6 +70,7 @@ pub struct CollectTokenItem {
     pub parent_id: SpanId,
     pub collect_id: usize,
     pub is_root: bool,
+    pub is_sampled: bool,
 }
 
 /// A struct representing the context of a span, including its [`TraceId`] and [`SpanId`].
@@ -80,6 +81,7 @@ pub struct CollectTokenItem {
 pub struct SpanContext {
     pub trace_id: TraceId,
     pub span_id: SpanId,
+    pub sampled: bool,
 }
 
 impl SpanContext {
@@ -96,7 +98,11 @@ impl SpanContext {
     /// [`TraceId`]: crate::collector::TraceId
     /// [`SpanId`]: crate::collector::SpanId
     pub fn new(trace_id: TraceId, span_id: SpanId) -> Self {
-        Self { trace_id, span_id }
+        Self {
+            trace_id,
+            span_id,
+            sampled: true,
+        }
     }
 
     /// Create a new `SpanContext` with a random trace id.
@@ -112,6 +118,7 @@ impl SpanContext {
         Self {
             trace_id: TraceId(rand::random()),
             span_id: SpanId::default(),
+            sampled: true,
         }
     }
 
@@ -142,6 +149,7 @@ impl SpanContext {
             Some(Self {
                 trace_id: collect_token.trace_id,
                 span_id: collect_token.parent_id,
+                sampled: collect_token.is_sampled,
             })
         }
     }
@@ -175,8 +183,28 @@ impl SpanContext {
             Some(Self {
                 trace_id: collect_token.trace_id,
                 span_id: collect_token.parent_id,
+                sampled: collect_token.is_sampled,
             })
         }
+    }
+
+    /// Sets the `sampled` flag of the `SpanContext`.
+    ///
+    /// The `sampled` flag will be propagated to the spans of the trace. But it will not
+    /// affect the behavior of `fastrace`. User may manually check the `sampled` flag
+    /// and call [`Span::cancel`] to cancel the trace.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fastrace::prelude::*;
+    ///
+    /// let span_context = SpanContext::new(TraceId(12), SpanId(34)).sampled(false);
+    /// ```
+    /// [`Span::cancel`]: crate::Span::cancel
+    pub fn sampled(mut self, sampled: bool) -> Self {
+        self.sampled = sampled;
+        self
     }
 
     /// Decodes the `SpanContext` from a [W3C Trace Context](https://www.w3.org/TR/trace-context/)
@@ -208,10 +236,11 @@ impl SpanContext {
             parts.next(),
             parts.next(),
         ) {
-            (Some("00"), Some(trace_id), Some(span_id), Some(_), None) => {
+            (Some("00"), Some(trace_id), Some(span_id), Some(sampled), None) => {
                 let trace_id = u128::from_str_radix(trace_id, 16).ok()?;
                 let span_id = u64::from_str_radix(span_id, 16).ok()?;
-                Some(Self::new(TraceId(trace_id), SpanId(span_id)))
+                let sampled = u8::from_str_radix(sampled, 16).ok()? != 0;
+                Some(Self::new(TraceId(trace_id), SpanId(span_id)).sampled(sampled))
             }
             _ => None,
         }
@@ -234,29 +263,9 @@ impl SpanContext {
     /// );
     /// ```
     pub fn encode_w3c_traceparent(&self) -> String {
-        Self::encode_w3c_traceparent_with_sampled(self, true)
-    }
-
-    /// Encodes the `SpanContext` as a [W3C Trace Context](https://www.w3.org/TR/trace-context/)
-    /// `traceparent` header string with a sampled flag.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::prelude::*;
-    ///
-    /// let span_context = SpanContext::new(TraceId(12), SpanId(34));
-    /// let traceparent = span_context.encode_w3c_traceparent_with_sampled(false);
-    ///
-    /// assert_eq!(
-    ///     traceparent,
-    ///     "00-0000000000000000000000000000000c-0000000000000022-00"
-    /// );
-    /// ```
-    pub fn encode_w3c_traceparent_with_sampled(&self, sampled: bool) -> String {
         format!(
             "00-{:032x}-{:016x}-{:02x}",
-            self.trace_id.0, self.span_id.0, sampled as u8,
+            self.trace_id.0, self.span_id.0, self.sampled as u8,
         )
     }
 }
@@ -376,7 +385,7 @@ mod tests {
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
         );
         assert_eq!(
-            span_context.encode_w3c_traceparent_with_sampled(false),
+            span_context.sampled(false).encode_w3c_traceparent(),
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
         );
     }

--- a/fastrace/src/local/local_collector.rs
+++ b/fastrace/src/local/local_collector.rs
@@ -257,6 +257,7 @@ mod tests {
                 parent_id: SpanId::default(),
                 collect_id: 42,
                 is_root: false,
+                is_sampled: true,
             };
             let collector2 = LocalCollector::new(Some(token2.into()), stack.clone());
             let span2 = stack.borrow_mut().enter_span("span2").unwrap();
@@ -296,6 +297,7 @@ span1 []
                 parent_id: SpanId::default(),
                 collect_id: 42,
                 is_root: false,
+                is_sampled: true,
             };
             let collector2 = LocalCollector::new(Some(token2.into()), stack.clone());
             let span2 = stack.borrow_mut().enter_span("span2").unwrap();

--- a/fastrace/src/local/local_span.rs
+++ b/fastrace/src/local/local_span.rs
@@ -209,6 +209,7 @@ mod tests {
             parent_id: SpanId::default(),
             collect_id: 42,
             is_root: false,
+            is_sampled: true,
         };
         let collector = LocalCollector::new(Some(token.into()), stack.clone());
 
@@ -246,6 +247,7 @@ span1 []
             parent_id: SpanId::default(),
             collect_id: 42,
             is_root: false,
+            is_sampled: true,
         };
         let collector = LocalCollector::new(Some(token.into()), stack.clone());
 

--- a/fastrace/src/local/local_span_line.rs
+++ b/fastrace/src/local/local_span_line.rs
@@ -83,6 +83,7 @@ impl SpanLine {
                         .unwrap_or(item.parent_id),
                     collect_id: item.collect_id,
                     is_root: false,
+                    is_sampled: true,
                 })
                 .collect()
         })
@@ -152,12 +153,14 @@ span1 []
             parent_id: SpanId::default(),
             collect_id: 42,
             is_root: false,
+            is_sampled: true,
         };
         let token2 = CollectTokenItem {
             trace_id: TraceId(1235),
             parent_id: SpanId::default(),
             collect_id: 43,
             is_root: false,
+            is_sampled: true,
         };
         let token = [token1, token2].iter().collect();
         let mut span_line = SpanLine::new(16, 1, Some(token));
@@ -174,12 +177,14 @@ span1 []
                 parent_id: span_line.span_queue.current_parent_id().unwrap(),
                 collect_id: 42,
                 is_root: false,
+                is_sampled: true,
             },
             CollectTokenItem {
                 trace_id: TraceId(1235),
                 parent_id: span_line.span_queue.current_parent_id().unwrap(),
                 collect_id: 43,
                 is_root: false,
+                is_sampled: true,
             }
         ]);
         span_line.finish_span(span);
@@ -223,6 +228,7 @@ span []
             parent_id: SpanId::default(),
             collect_id: 42,
             is_root: false,
+            is_sampled: true,
         };
         let mut span_line1 = SpanLine::new(16, 1, Some(item.into()));
         let mut span_line2 = SpanLine::new(16, 2, None);

--- a/fastrace/src/local/local_span_stack.rs
+++ b/fastrace/src/local/local_span_stack.rs
@@ -147,6 +147,7 @@ mod tests {
             parent_id: SpanId::default(),
             collect_id: 42,
             is_root: false,
+            is_sampled: true,
         };
         let span_line1 = span_stack.register_span_line(Some(token1.into())).unwrap();
         {
@@ -164,6 +165,7 @@ mod tests {
                 parent_id: SpanId::default(),
                 collect_id: 48,
                 is_root: false,
+                is_sampled: true,
             };
             let span_line2 = span_stack.register_span_line(Some(token2.into())).unwrap();
             {
@@ -212,6 +214,7 @@ span1 []
                             parent_id: SpanId::default(),
                             collect_id: 42,
                             is_root: false,
+                            is_sampled: true,
                         }
                         .into(),
                     ))
@@ -227,6 +230,7 @@ span1 []
                                         parent_id: SpanId::default(),
                                         collect_id: 43,
                                         is_root: false,
+                                        is_sampled: true,
                                     }
                                     .into()
                                 ))
@@ -247,6 +251,7 @@ span1 []
                                         parent_id: SpanId::default(),
                                         collect_id: 44,
                                         is_root: false,
+                                        is_sampled: true,
                                     }
                                     .into()
                                 ))
@@ -272,6 +277,7 @@ span1 []
             parent_id: SpanId(1),
             collect_id: 1,
             is_root: false,
+            is_sampled: true,
         };
         let span_line1 = span_stack.register_span_line(Some(token1.into())).unwrap();
         assert_eq!(span_stack.current_collect_token().unwrap().as_slice(), &[
@@ -286,6 +292,7 @@ span1 []
                     parent_id: SpanId(3),
                     collect_id: 3,
                     is_root: false,
+                    is_sampled: true,
                 };
                 let span_line3 = span_stack.register_span_line(Some(token3.into())).unwrap();
                 assert_eq!(span_stack.current_collect_token().unwrap().as_slice(), &[
@@ -301,6 +308,7 @@ span1 []
                 parent_id: SpanId(4),
                 collect_id: 4,
                 is_root: false,
+                is_sampled: true,
             };
             let span_line4 = span_stack.register_span_line(Some(token4.into())).unwrap();
             assert_eq!(span_stack.current_collect_token().unwrap().as_slice(), &[
@@ -329,6 +337,7 @@ span1 []
                         parent_id: SpanId::default(),
                         collect_id: 42,
                         is_root: false,
+                        is_sampled: true,
                     }
                     .into(),
                 ))
@@ -353,6 +362,7 @@ span1 []
                         parent_id: SpanId::default(),
                         collect_id: 42,
                         is_root: false,
+                        is_sampled: true,
                     }
                     .into(),
                 ))
@@ -377,6 +387,7 @@ span1 []
                         parent_id: SpanId::default(),
                         collect_id: 42,
                         is_root: false,
+                        is_sampled: true,
                     }
                     .into(),
                 ))

--- a/fastrace/src/span.rs
+++ b/fastrace/src/span.rs
@@ -88,6 +88,7 @@ impl Span {
                 parent_id: parent.span_id,
                 collect_id,
                 is_root: true,
+                is_sampled: parent.sampled,
             }
             .into();
             Self::new(token, name, Some(collect_id))
@@ -456,6 +457,7 @@ impl SpanInner {
                 parent_id: self.raw_span.id,
                 collect_id: collect_item.collect_id,
                 is_root: false,
+                is_sampled: collect_item.is_sampled,
             })
     }
 
@@ -594,6 +596,7 @@ mod tests {
                         parent_id: SpanId::default(),
                         collect_id: 42,
                         is_root: true,
+                        is_sampled: true,
                     }
                     .into(),
                 ),


### PR DESCRIPTION
- **build: ensure msrv 1.80.1 and upgrade dependencies (#20)**
- **chore: update crate metadata to reflect the transfer (#23)**
- **chore(doc): enrich guide for logging (#19)**
- **refactor: pass `Vec<SpanRecord>` to `Reporter::report()` instead of `&[SpanRecord]` (#25)**
- **fix readme link (#26)**
- **chore: drop the effectively deprecated author meta field (#27)**
- **fix LocalSpan's method's comment (#28)**
- **feat: add SpanContext::sampled**
