### PR TITLE
Optimize pool

### DIFF
--- a/fastrace/src/collector/global_collector.rs
+++ b/fastrace/src/collector/global_collector.rs
@@ -229,14 +229,16 @@ impl GlobalCollector {
         {
             std::thread::Builder::new()
                 .name("fastrace-global-collector".to_string())
-                .spawn(move || loop {
-                    let begin_instant = Instant::now();
-                    GLOBAL_COLLECTOR.lock().as_mut().unwrap().handle_commands();
-                    std::thread::sleep(
-                        config
-                            .report_interval
-                            .saturating_sub(begin_instant.elapsed()),
-                    );
+                .spawn(move || {
+                    loop {
+                        let begin_instant = Instant::now();
+                        GLOBAL_COLLECTOR.lock().as_mut().unwrap().handle_commands();
+                        std::thread::sleep(
+                            config
+                                .report_interval
+                                .saturating_sub(begin_instant.elapsed()),
+                        );
+                    }
                 })
                 .unwrap();
         }

--- a/fastrace/src/util/mod.rs
+++ b/fastrace/src/util/mod.rs
@@ -9,52 +9,48 @@ pub mod tree;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
-use once_cell::sync::Lazy;
-
 use crate::collector::CollectTokenItem;
 use crate::local::raw_span::RawSpan;
-use crate::util::object_pool::Pool;
-use crate::util::object_pool::Puller;
-use crate::util::object_pool::Reusable;
+use crate::util::object_pool::GlobalVecPool;
+use crate::util::object_pool::LocalVecPool;
+use crate::util::object_pool::ReusableVec;
 
-static RAW_SPANS_POOL: Lazy<Pool<Vec<RawSpan>>> = Lazy::new(|| Pool::new(Vec::new, Vec::clear));
-static COLLECT_TOKEN_ITEMS_POOL: Lazy<Pool<Vec<CollectTokenItem>>> =
-    Lazy::new(|| Pool::new(Vec::new, Vec::clear));
-#[allow(clippy::type_complexity)]
-static PROPERTIES_POOL: Lazy<Pool<Vec<(Cow<'static, str>, Cow<'static, str>)>>> =
-    Lazy::new(|| Pool::new(Vec::new, Vec::clear));
+static RAW_SPANS_POOL: GlobalVecPool<RawSpan> = GlobalVecPool::new();
+static COLLECT_TOKEN_ITEMS_POOL: GlobalVecPool<CollectTokenItem> = GlobalVecPool::new();
+static PROPERTIES_POOL: GlobalVecPool<(Cow<'static, str>, Cow<'static, str>)> =
+    GlobalVecPool::new();
 
 thread_local! {
-    static RAW_SPANS_PULLER: RefCell<Puller<'static, Vec<RawSpan>>> = RefCell::new(RAW_SPANS_POOL.puller(512));
-    static COLLECT_TOKEN_ITEMS_PULLER: RefCell<Puller<'static, Vec<CollectTokenItem>>>  = RefCell::new(COLLECT_TOKEN_ITEMS_POOL.puller(512));
+    static RAW_SPANS_PULLER: RefCell<LocalVecPool<RawSpan>> = RefCell::new(RAW_SPANS_POOL.new_local(512));
+    static COLLECT_TOKEN_ITEMS_PULLER: RefCell<LocalVecPool<CollectTokenItem>>  = RefCell::new(COLLECT_TOKEN_ITEMS_POOL.new_local(512));
     #[allow(clippy::type_complexity)]
-    static PROPERTIES_PULLER: RefCell<Puller<'static, Vec<(Cow<'static, str>, Cow<'static, str>)>>>  = RefCell::new(PROPERTIES_POOL.puller(512));
+    static PROPERTIES_PULLER: RefCell<LocalVecPool<(Cow<'static, str>, Cow<'static, str>)>>  = RefCell::new(PROPERTIES_POOL.new_local(512));
 }
 
-pub type RawSpans = Reusable<'static, Vec<RawSpan>>;
-pub type CollectToken = Reusable<'static, Vec<CollectTokenItem>>;
-pub type Properties = Reusable<'static, Vec<(Cow<'static, str>, Cow<'static, str>)>>;
+pub type RawSpans = ReusableVec<RawSpan>;
+pub type CollectToken = ReusableVec<CollectTokenItem>;
+pub type Properties = ReusableVec<(Cow<'static, str>, Cow<'static, str>)>;
 
 impl Default for RawSpans {
     fn default() -> Self {
         RAW_SPANS_PULLER
-            .try_with(|puller| puller.borrow_mut().pull())
-            .unwrap_or_else(|_| Reusable::new(&*RAW_SPANS_POOL, vec![]))
+            .try_with(|puller| puller.borrow_mut().take())
+            .unwrap_or_else(|_| Self::new(&RAW_SPANS_POOL, Vec::new()))
     }
 }
 
 impl Default for Properties {
     fn default() -> Self {
         PROPERTIES_PULLER
-            .try_with(|puller| puller.borrow_mut().pull())
-            .unwrap_or_else(|_| Reusable::new(&*PROPERTIES_POOL, vec![]))
+            .try_with(|puller| puller.borrow_mut().take())
+            .unwrap_or_else(|_| Self::new(&PROPERTIES_POOL, Vec::new()))
     }
 }
 
 fn new_collect_token(items: impl IntoIterator<Item = CollectTokenItem>) -> CollectToken {
     let mut token = COLLECT_TOKEN_ITEMS_PULLER
-        .try_with(|puller| puller.borrow_mut().pull())
-        .unwrap_or_else(|_| Reusable::new(&*COLLECT_TOKEN_ITEMS_POOL, vec![]));
+        .try_with(|puller| puller.borrow_mut().take())
+        .unwrap_or_else(|_| CollectToken::new(&COLLECT_TOKEN_ITEMS_POOL, Vec::new()));
     token.extend(items);
     token
 }

--- a/fastrace/src/util/object_pool.rs
+++ b/fastrace/src/util/object_pool.rs
@@ -14,6 +14,12 @@ where T: 'static
     storage: Mutex<Vec<Vec<T>>>,
 }
 
+impl<T> Default for GlobalVecPool<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> GlobalVecPool<T> {
     pub const fn new() -> Self {
         Self {

--- a/fastrace/src/util/object_pool.rs
+++ b/fastrace/src/util/object_pool.rs
@@ -1,16 +1,15 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    fmt,
-    mem::{self, ManuallyDrop},
-    ops, slice,
-    sync::Mutex,
-};
+use std::fmt;
+use std::mem::ManuallyDrop;
+use std::mem::{self};
+use std::ops;
+use std::slice;
+use std::sync::Mutex;
 
 #[must_use]
 pub struct GlobalVecPool<T>
-where
-    T: 'static,
+where T: 'static
 {
     storage: Mutex<Vec<Vec<T>>>,
 }
@@ -147,8 +146,7 @@ pub struct ReusableVec<T: 'static> {
 }
 
 impl<T> PartialEq for ReusableVec<T>
-where
-    T: PartialEq,
+where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
         self.data.eq(&other.data)
@@ -156,8 +154,7 @@ where
 }
 
 impl<T> fmt::Debug for ReusableVec<T>
-where
-    T: fmt::Debug,
+where T: fmt::Debug
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.data.fmt(f)


### PR DESCRIPTION
1) Global pool contains vectors only with capacity
2) Thread pool contains vectors from global pool (with capacity) OR without capacity
3) Vectors are returned to the global pool only if they have capacity
4) For the reason from p.3, the `REUSABLE` flag is not needed.
5) Also added the `stub` method - which allows not to access to the pool if we do not use attributes (events, impl `Log`, etc)


```
compare/fastrace/1      time:   [304.18 ns 305.64 ns 307.36 ns]
                        change: [-20.521% -19.831% -19.062%] (p = 0.00 < 0.05)
                        Performance has improved.

compare/fastrace/10     time:   [772.85 ns 778.27 ns 784.07 ns]
                        change: [-17.300% -16.547% -15.815%] (p = 0.00 < 0.05)
                        Performance has improved.
                        
Vec::with_capacity/object-pool/1
                        time:   [2.4597 ns 2.4679 ns 2.4767 ns]
                        change: [-20.663% -20.296% -19.938%] (p = 0.00 < 0.05)
                        Performance has improved.
Vec::with_capacity/alloc/1
                        time:   [6.4638 ns 6.5043 ns 6.5405 ns]
                        change: [+3.4161% +4.4540% +5.4969%] (p = 0.00 < 0.05)
                        Performance has regressed.

Vec::with_capacity/object-pool/10
                        time:   [2.4700 ns 2.4789 ns 2.4874 ns]
                        change: [-21.023% -20.561% -20.111%] (p = 0.00 < 0.05)
                        Performance has improved.
                        
Vec::with_capacity/object-pool/100
                        time:   [2.4590 ns 2.4682 ns 2.4777 ns]
                        change: [-19.639% -19.239% -18.845%] (p = 0.00 < 0.05)
                        Performance has improved.
                        
Vec::with_capacity/alloc/100
                        time:   [23.783 ns 23.911 ns 24.035 ns]
                        change: [+2.1886% +2.8602% +3.5167%] (p = 0.00 < 0.05)
                        Performance has regressed.
                        
Vec::with_capacity/object-pool/1000
                        time:   [2.5000 ns 2.5112 ns 2.5226 ns]
                        change: [-22.018% -21.560% -21.106%] (p = 0.00 < 0.05)
                        Performance has improved.
                        
Vec::with_capacity/object-pool/10000
                        time:   [2.4538 ns 2.4601 ns 2.4668 ns]
                        change: [-19.391% -19.038% -18.683%] (p = 0.00 < 0.05)
                        Performance has improved.

Vec::with_capacity/alloc/10000
                        time:   [28.905 ns 29.037 ns 29.179 ns]
                        change: [-2.5027% -2.0210% -1.5147%] (p = 0.00 < 0.05)
                        Performance has improved.

trace_wide_raw/10       time:   [1.1964 µs 1.2004 µs 1.2051 µs]
                        change: [-15.850% -15.476% -15.088%] (p = 0.00 < 0.05)
                        Performance has improved.

trace_wide_raw/100      time:   [11.310 µs 11.360 µs 11.408 µs]
                        change: [-7.1389% -6.7624% -6.3728%] (p = 0.00 < 0.05)
                        Performance has improved.

trace_wide_raw/1000     time:   [112.11 µs 112.49 µs 112.91 µs]
                        change: [-7.0186% -6.4420% -5.8764%] (p = 0.00 < 0.05)
                        Performance has improved.
```