### PR TITLE
chore: remove clippy mitigation lint rule

### DIFF
--- a/fastrace/Cargo.toml
+++ b/fastrace/Cargo.toml
@@ -75,7 +75,3 @@ name = "spsc"
 [[bench]]
 harness = false
 name = "object_pool"
-
-[lints.clippy]
-# https://github.com/rust-lang/rust-clippy/issues/13458
-needless_return = "allow"


### PR DESCRIPTION
As https://github.com/rust-lang/rust-clippy/issues/13458 is fixed on nightly. Let's remove the mitigation lint rule.