### PR TITLE
refactor: upgrade otel deps and rewrite the integrations 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ fastrace-opentelemetry = { path = "fastrace-opentelemetry" }
 # crates.io dependencies
 futures = { version = "0.3" }
 log = { version = "0.4" }
-opentelemetry = { version = "0.27", features = ["trace"] }
-opentelemetry_sdk = { version = "0.27", features = ["trace"] }
-opentelemetry-otlp = { version = "0.27", features = ["trace"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ fastrace-opentelemetry = { path = "fastrace-opentelemetry" }
 # crates.io dependencies
 futures = { version = "0.3" }
 log = { version = "0.4" }
+opentelemetry = { version = "0.27", features = ["trace"] }
+opentelemetry_sdk = { version = "0.27", features = ["trace"] }
+opentelemetry-otlp = { version = "0.27", features = ["trace"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [profile.bench]

--- a/fastrace-opentelemetry/Cargo.toml
+++ b/fastrace-opentelemetry/Cargo.toml
@@ -13,14 +13,17 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+bundle = ["dep:opentelemetry-otlp"]
+
 [dependencies]
 fastrace = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 log = { workspace = true }
-opentelemetry = { version = "0.26", features = ["trace"] }
-opentelemetry_sdk = { version = "0.26", features = ["trace"] }
+opentelemetry = { version = "0.27.0", features = ["trace"] }
+opentelemetry_sdk = { version = "0.27.0", features = ["trace"] }
+opentelemetry-otlp = { version = "0.27.0", features = ["trace"], optional = true }
 
 [dev-dependencies]
-opentelemetry-otlp = { version = "0.26", features = ["trace"] }
 rand = "0.8"
-tokio = { version = "1.38", features = ["rt-multi-thread"] }
+tokio = { version = "1.41", features = ["rt-multi-thread"] }

--- a/fastrace-opentelemetry/Cargo.toml
+++ b/fastrace-opentelemetry/Cargo.toml
@@ -14,16 +14,15 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-bundle = ["dep:opentelemetry-otlp"]
 
 [dependencies]
 fastrace = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 log = { workspace = true }
-opentelemetry = { version = "0.27.0", features = ["trace"] }
-opentelemetry_sdk = { version = "0.27.0", features = ["trace"] }
-opentelemetry-otlp = { version = "0.27.0", features = ["trace"], optional = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
 
 [dev-dependencies]
+opentelemetry-otlp = { workspace = true }
 rand = "0.8"
 tokio = { version = "1.41", features = ["rt-multi-thread"] }

--- a/fastrace-opentelemetry/Cargo.toml
+++ b/fastrace-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastrace-opentelemetry"
-version = "0.7.4"
+version = "0.8.0"
 
 categories = ["development-tools::debugging"]
 description = "Opentelemetry reporter for fastrace"
@@ -13,16 +13,14 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[features]
-
 [dependencies]
 fastrace = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 log = { workspace = true }
-opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+opentelemetry = { version = "0.27", features = ["trace"] }
+opentelemetry_sdk = { version = "0.27", features = ["trace"] }
 
 [dev-dependencies]
-opentelemetry-otlp = { workspace = true }
+opentelemetry-otlp = { version = "0.27", features = ["trace"] }
 rand = "0.8"
 tokio = { version = "1.41", features = ["rt-multi-thread"] }

--- a/fastrace-opentelemetry/README.md
+++ b/fastrace-opentelemetry/README.md
@@ -16,10 +16,15 @@ fastrace-opentelemetry = "0.7"
 
 ## Setup OpenTelemetry Collector
 
-```shell
-cd fastrace-opentelemetry/examples
-docker compose up -d
+Start OpenTelemetry Collector with Jaeger and Zipkin receivers:
 
+```shell
+docker compose -f examples/docker-compose.yaml up
+```
+
+Then, run the synchronous example:
+
+```shell
 cargo run --example synchronous
 ```
 

--- a/fastrace-opentelemetry/README.md
+++ b/fastrace-opentelemetry/README.md
@@ -16,7 +16,7 @@ fastrace-opentelemetry = "0.7"
 
 ## Setup OpenTelemetry Collector
 
-```sh
+```shell
 cd fastrace-opentelemetry/examples
 docker compose up -d
 
@@ -35,27 +35,30 @@ use std::time::Duration;
 use fastrace::collector::Config;
 use fastrace::prelude::*;
 use fastrace_opentelemetry::OpenTelemetryReporter;
-use opentelemetry_otlp::{SpanExporter, ExportConfig, Protocol, TonicConfig};
+use opentelemetry_otlp::ExportConfig;
+use opentelemetry_otlp::Protocol;
+use opentelemetry_otlp::SpanExporter;
+use opentelemetry_otlp::TonicConfig;
 use opentelemetry::trace::SpanKind;
 use opentelemetry_sdk::Resource;
 use opentelemetry::KeyValue;
-use opentelemetry::InstrumentationLibrary;
+use opentelemetry::InstrumentationScope;
 use opentelemetry_otlp::WithExportConfig;
 
 // Initialize reporter
 let reporter = OpenTelemetryReporter::new(
-    opentelemetry_otlp::new_exporter()
-        .tonic()
+    SpanExporter::builder()
+        .with_tonic()
         .with_endpoint("http://127.0.0.1:4317".to_string())
         .with_protocol(opentelemetry_otlp::Protocol::Grpc)
         .with_timeout(Duration::from_secs(
             opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT,
         ))
-        .build_span_exporter()
+        .build()
         .expect("initialize oltp exporter"),
     SpanKind::Server,
     Cow::Owned(Resource::new([KeyValue::new("service.name", "asynchronous")])),
-    InstrumentationLibrary::builder("example-crate").with_version(env!("CARGO_PKG_VERSION")).build(),
+    InstrumentationScope::builder("example-crate").with_version(env!("CARGO_PKG_VERSION")).build(),
 );
 fastrace::set_reporter(reporter, Config::default());
 

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -18,13 +18,6 @@
 
 #![doc = include_str!("../README.md")]
 
-#[cfg(feature = "bundle")]
-pub extern crate opentelemetry;
-#[cfg(feature = "bundle")]
-pub extern crate opentelemetry_otlp;
-#[cfg(feature = "bundle")]
-pub extern crate opentelemetry_sdk;
-
 use std::borrow::Cow;
 use std::time::Duration;
 use std::time::SystemTime;

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -1,15 +1,38 @@
+// Copyright 2024 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is derived from [1] under the original license header:
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+// [1]: https://github.com/tikv/minitrace-rust/blob/v0.6.4/minitrace-opentelemetry/src/lib.rs
 
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "bundle")]
+extern crate opentelemetry;
+#[cfg(feature = "bundle")]
+extern crate opentelemetry_otlp;
+#[cfg(feature = "bundle")]
+extern crate opentelemetry_sdk;
+
 use std::borrow::Cow;
 use std::time::Duration;
-use std::time::UNIX_EPOCH;
+use std::time::SystemTime;
 
 use fastrace::collector::EventRecord;
 use fastrace::collector::Reporter;
 use fastrace::prelude::*;
-use opentelemetry::InstrumentationLibrary;
+use opentelemetry::InstrumentationScope;
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use opentelemetry::StringValue;
@@ -28,12 +51,49 @@ use opentelemetry_sdk::trace::SpanLinks;
 
 /// [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-rust) reporter for `fastrace`.
 ///
-/// `OpenTelemetryReporter` exports trace records to remote agents that OpenTelemetry
-/// supports, which includes Jaeger, Datadog, Zipkin, and OpenTelemetry Collector.
+/// `OpenTelemetryReporter` exports trace records to remote agents that implements the
+/// OpenTelemetry protocol, such as Jaeger, Zipkin, and OpenTelemetry Collector.
 pub struct OpenTelemetryReporter {
     exporter: Box<dyn SpanExporter>,
     span_kind: SpanKind,
-    instrumentation_lib: InstrumentationLibrary,
+    instrumentation_scope: InstrumentationScope,
+}
+
+/// Calculate the start time of a span.
+fn span_start_time(span: &SpanRecord) -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_nanos(span.begin_time_unix_ns)
+}
+
+/// Calculate the end time of a span.
+fn span_end_time(span: &SpanRecord) -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_nanos(span.begin_time_unix_ns + span.duration_ns)
+}
+
+/// Convert a list of properties to a list of key-value pairs.
+fn props_to_kvs(props: Vec<(Cow<'static, str>, Cow<'static, str>)>) -> Vec<KeyValue> {
+    props
+        .into_iter()
+        .map(|(k, v)| KeyValue::new(k, v))
+        .collect()
+}
+
+/// Convert a list of [`EventRecord`] to OpenTelemetry [`SpanEvents`].
+fn map_events(events: Vec<EventRecord>) -> SpanEvents {
+    let mut queue = SpanEvents::default();
+    queue.events.reserve(events.len());
+
+    for EventRecord {
+        name,
+        timestamp_unix_ns,
+        properties,
+    } in events
+    {
+        let time = SystemTime::UNIX_EPOCH + Duration::from_nanos(timestamp_unix_ns);
+        let attributes = props_to_kvs(properties);
+        queue.events.push(Event::new(name, time, attributes, 0));
+    }
+
+    queue
 }
 
 impl OpenTelemetryReporter {
@@ -41,20 +101,20 @@ impl OpenTelemetryReporter {
         mut exporter: impl SpanExporter + 'static,
         span_kind: SpanKind,
         resource: Cow<'static, Resource>,
-        instrumentation_lib: InstrumentationLibrary,
+        instrumentation_scope: InstrumentationScope,
     ) -> Self {
         exporter.set_resource(&resource);
         OpenTelemetryReporter {
             exporter: Box::new(exporter),
             span_kind,
-            instrumentation_lib,
+            instrumentation_scope,
         }
     }
 
     fn convert(&self, spans: Vec<SpanRecord>) -> Vec<SpanData> {
         spans
             .into_iter()
-            .map(move |span| SpanData {
+            .map(|span| SpanData {
                 span_context: SpanContext::new(
                     span.trace_id.0.into(),
                     span.span_id.0.into(),
@@ -65,49 +125,21 @@ impl OpenTelemetryReporter {
                 dropped_attributes_count: 0,
                 parent_span_id: span.parent_id.0.into(),
                 name: span.name,
-                start_time: UNIX_EPOCH + Duration::from_nanos(span.begin_time_unix_ns),
-                end_time: UNIX_EPOCH
-                    + Duration::from_nanos(span.begin_time_unix_ns + span.duration_ns),
-                attributes: Self::convert_properties(span.properties),
-                events: Self::convert_events(span.events),
+                start_time: span_start_time(&span),
+                end_time: span_end_time(&span),
+                attributes: props_to_kvs(span.properties),
+                events: map_events(span.events),
                 links: SpanLinks::default(),
                 status: Status::default(),
                 span_kind: self.span_kind.clone(),
-                instrumentation_lib: self.instrumentation_lib.clone(),
+                instrumentation_scope: self.instrumentation_scope.clone(),
             })
             .collect()
     }
 
-    fn convert_properties(
-        properties: Vec<(Cow<'static, str>, Cow<'static, str>)>,
-    ) -> Vec<KeyValue> {
-        let mut map = Vec::new();
-        for (k, v) in properties {
-            map.push(KeyValue::new(cow_to_otel_key(k), cow_to_otel_value(v)));
-        }
-        map
-    }
-
-    fn convert_events(events: Vec<EventRecord>) -> SpanEvents {
-        let mut queue = SpanEvents::default();
-        queue.events.extend(events.into_iter().map(|event| {
-            Event::new(
-                event.name,
-                UNIX_EPOCH + Duration::from_nanos(event.timestamp_unix_ns),
-                event
-                    .properties
-                    .into_iter()
-                    .map(|(k, v)| KeyValue::new(cow_to_otel_key(k), cow_to_otel_value(v)))
-                    .collect(),
-                0,
-            )
-        }));
-        queue
-    }
-
     fn try_report(&mut self, spans: Vec<SpanRecord>) -> Result<(), Box<dyn std::error::Error>> {
-        let opentelemetry_spans = self.convert(spans);
-        futures::executor::block_on(self.exporter.export(opentelemetry_spans))?;
+        let spans = self.convert(spans);
+        futures::executor::block_on(self.exporter.export(spans))?;
         Ok(())
     }
 }
@@ -119,21 +151,7 @@ impl Reporter for OpenTelemetryReporter {
         }
 
         if let Err(err) = self.try_report(spans) {
-            log::error!("report to opentelemetry failed: {}", err);
+            log::error!("failed to report to opentelemetry: {err}");
         }
-    }
-}
-
-fn cow_to_otel_key(cow: Cow<'static, str>) -> Key {
-    match cow {
-        Cow::Borrowed(s) => Key::from_static_str(s),
-        Cow::Owned(s) => Key::from(s),
-    }
-}
-
-fn cow_to_otel_value(cow: Cow<'static, str>) -> Value {
-    match cow {
-        Cow::Borrowed(s) => Value::String(StringValue::from(s)),
-        Cow::Owned(s) => Value::String(StringValue::from(s)),
     }
 }

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -19,11 +19,11 @@
 #![doc = include_str!("../README.md")]
 
 #[cfg(feature = "bundle")]
-extern crate opentelemetry;
+pub extern crate opentelemetry;
 #[cfg(feature = "bundle")]
-extern crate opentelemetry_otlp;
+pub extern crate opentelemetry_otlp;
 #[cfg(feature = "bundle")]
-extern crate opentelemetry_sdk;
+pub extern crate opentelemetry_sdk;
 
 use std::borrow::Cow;
 use std::time::Duration;
@@ -49,7 +49,7 @@ use opentelemetry_sdk::trace::SpanLinks;
 /// [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-rust) reporter for `fastrace`.
 ///
 /// `OpenTelemetryReporter` exports trace records to remote agents that implements the
-/// OpenTelemetry protocol, such as Jaeger, Zipkin, and OpenTelemetry Collector.
+/// OpenTelemetry protocol, such as Jaeger, Zipkin, etc.
 pub struct OpenTelemetryReporter {
     exporter: Box<dyn SpanExporter>,
     span_kind: SpanKind,

--- a/fastrace/Cargo.toml
+++ b/fastrace/Cargo.toml
@@ -34,17 +34,14 @@ crossbeam = "0.8"
 fastrace = { workspace = true, features = ["enable"] }
 fastrace-datadog = { workspace = true }
 fastrace-jaeger = { workspace = true }
-fastrace-opentelemetry = { workspace = true }
+fastrace-opentelemetry = { workspace = true, features = ["bundle"] }
 flume = "0.11"
 futures = { workspace = true }
 futures-timer = "3"
 log = { workspace = true }
 logcall = "0.1"
-logforth = { version = "0.16", features = ["fastrace"] }
+logforth = { version = "0.18", features = ["fastrace"] }
 mockall = "0.13"
-opentelemetry = { version = "0.26", features = ["trace"] }
-opentelemetry-otlp = { version = "0.26", features = ["trace"] }
-opentelemetry_sdk = { version = "0.26", features = ["trace"] }
 rand = "0.8"
 rustracing = "0.6"
 serial_test = "3.1"

--- a/fastrace/Cargo.toml
+++ b/fastrace/Cargo.toml
@@ -42,9 +42,9 @@ log = { workspace = true }
 logcall = "0.1"
 logforth = { version = "0.18", features = ["fastrace"] }
 mockall = "0.13"
-opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
-opentelemetry-otlp = { workspace = true }
+opentelemetry = { version = "0.27", features = ["trace"] }
+opentelemetry_sdk = { version = "0.27", features = ["trace"] }
+opentelemetry-otlp = { version = "0.27", features = ["trace"] }
 rand = "0.8"
 rustracing = "0.6"
 serial_test = "3.1"

--- a/fastrace/Cargo.toml
+++ b/fastrace/Cargo.toml
@@ -34,7 +34,7 @@ crossbeam = "0.8"
 fastrace = { workspace = true, features = ["enable"] }
 fastrace-datadog = { workspace = true }
 fastrace-jaeger = { workspace = true }
-fastrace-opentelemetry = { workspace = true, features = ["bundle"] }
+fastrace-opentelemetry = { workspace = true }
 flume = "0.11"
 futures = { workspace = true }
 futures-timer = "3"
@@ -42,6 +42,9 @@ log = { workspace = true }
 logcall = "0.1"
 logforth = { version = "0.18", features = ["fastrace"] }
 mockall = "0.13"
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 rand = "0.8"
 rustracing = "0.6"
 serial_test = "3.1"

--- a/fastrace/examples/asynchronous.rs
+++ b/fastrace/examples/asynchronous.rs
@@ -24,10 +24,7 @@ use std::time::Duration;
 use fastrace::collector::Config;
 use fastrace::collector::Reporter;
 use fastrace::prelude::*;
-use fastrace_opentelemetry::opentelemetry;
-use fastrace_opentelemetry::opentelemetry_otlp;
-use fastrace_opentelemetry::opentelemetry_otlp::WithExportConfig;
-use fastrace_opentelemetry::opentelemetry_sdk;
+use opentelemetry_otlp::WithExportConfig;
 
 fn parallel_job() -> Vec<tokio::task::JoinHandle<()>> {
     let mut v = Vec::with_capacity(4);

--- a/fastrace/examples/asynchronous.rs
+++ b/fastrace/examples/asynchronous.rs
@@ -1,4 +1,20 @@
+// Copyright 2024 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is derived from [1] under the original license header:
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+// [1]: https://github.com/tikv/minitrace-rust/blob/v0.6.4/minitrace/examples/asynchronous.rs
 
 #![allow(clippy::new_without_default)]
 
@@ -8,7 +24,10 @@ use std::time::Duration;
 use fastrace::collector::Config;
 use fastrace::collector::Reporter;
 use fastrace::prelude::*;
-use opentelemetry_otlp::WithExportConfig;
+use fastrace_opentelemetry::opentelemetry;
+use fastrace_opentelemetry::opentelemetry_otlp;
+use fastrace_opentelemetry::opentelemetry_otlp::WithExportConfig;
+use fastrace_opentelemetry::opentelemetry_sdk;
 
 fn parallel_job() -> Vec<tokio::task::JoinHandle<()>> {
     let mut v = Vec::with_capacity(4);
@@ -38,7 +57,7 @@ async fn other_job() {
 
 #[tokio::main]
 async fn main() {
-    fastrace::set_reporter(ReportAll::new(), Config::default());
+    fastrace::set_reporter(ReportAll::create(), Config::default());
 
     {
         let parent = SpanContext::random();
@@ -72,7 +91,7 @@ pub struct ReportAll {
 }
 
 impl ReportAll {
-    pub fn new() -> ReportAll {
+    pub fn create() -> ReportAll {
         ReportAll {
             jaeger: fastrace_jaeger::JaegerReporter::new(
                 "127.0.0.1:6831".parse().unwrap(),
@@ -86,20 +105,20 @@ impl ReportAll {
                 "select",
             ),
             opentelemetry: fastrace_opentelemetry::OpenTelemetryReporter::new(
-                opentelemetry_otlp::new_exporter()
-                    .tonic()
+                opentelemetry_otlp::SpanExporter::builder()
+                    .with_tonic()
                     .with_endpoint("http://127.0.0.1:4317".to_string())
                     .with_protocol(opentelemetry_otlp::Protocol::Grpc)
                     .with_timeout(Duration::from_secs(
                         opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT,
                     ))
-                    .build_span_exporter()
+                    .build()
                     .expect("initialize oltp exporter"),
                 opentelemetry::trace::SpanKind::Server,
                 Cow::Owned(opentelemetry_sdk::Resource::new([
                     opentelemetry::KeyValue::new("service.name", "asynchronous(opentelemetry)"),
                 ])),
-                opentelemetry::InstrumentationLibrary::builder("example-crate")
+                opentelemetry::InstrumentationScope::builder("example-crate")
                     .with_version(env!("CARGO_PKG_VERSION"))
                     .build(),
             ),

--- a/fastrace/examples/synchronous.rs
+++ b/fastrace/examples/synchronous.rs
@@ -22,10 +22,7 @@ use std::time::Duration;
 use fastrace::collector::Config;
 use fastrace::collector::Reporter;
 use fastrace::prelude::*;
-use fastrace_opentelemetry::opentelemetry;
-use fastrace_opentelemetry::opentelemetry_otlp;
-use fastrace_opentelemetry::opentelemetry_otlp::WithExportConfig;
-use fastrace_opentelemetry::opentelemetry_sdk;
+use opentelemetry_otlp::WithExportConfig;
 
 fn func1(i: u64) {
     let _guard = LocalSpan::enter_with_local_parent("func1");


### PR DESCRIPTION
Open question:

Shall we re-export all otel related crates, or spawn fastrace-opentelemetry support a separate lifetime to release?

I suppose we can anyway reduce the necessity of `bundle` once opentelemetry-rust releases a 1.0 so that the API is stable.