### PR TITLE
chore: reduce dependencies on futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ fastrace-jaeger = { path = "fastrace-jaeger" }
 fastrace-opentelemetry = { path = "fastrace-opentelemetry" }
 
 # crates.io dependencies
-futures = { version = "0.3" }
 log = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/fastrace-datadog/Cargo.toml
+++ b/fastrace-datadog/Cargo.toml
@@ -21,4 +21,3 @@ rmp-serde = "1.3"
 serde = { workspace = true }
 
 [dev-dependencies]
-futures = { workspace = true }

--- a/fastrace-futures/Cargo.toml
+++ b/fastrace-futures/Cargo.toml
@@ -15,9 +15,11 @@ rust-version.workspace = true
 
 [dependencies]
 fastrace = { workspace = true }
-futures = { workspace = true }
+futures-core = { version = "0.3.31" }
+futures-sink = { version = "0.3.31" }
 pin-project = { version = "1.1.8" }
 
 [dev-dependencies]
-async-stream = "0.3"
+async-stream = { version = "0.3" }
+futures = { version = "0.3" }
 tokio = { version = "1.38", features = ["rt", "time", "macros"] }

--- a/fastrace-futures/src/lib.rs
+++ b/fastrace-futures/src/lib.rs
@@ -7,8 +7,8 @@ use std::task::Context;
 use std::task::Poll;
 
 use fastrace::Span;
-use futures::Sink;
-use futures::Stream;
+use futures_core::Stream;
+use futures_sink::Sink;
 
 /// An extension trait for [`Stream`] that provides tracing instrument adapters.
 pub trait StreamExt: Stream + Sized {

--- a/fastrace-jaeger/Cargo.toml
+++ b/fastrace-jaeger/Cargo.toml
@@ -19,4 +19,3 @@ log = { workspace = true }
 thrift_codec = "0.3"
 
 [dev-dependencies]
-futures = { workspace = true }

--- a/fastrace-opentelemetry/Cargo.toml
+++ b/fastrace-opentelemetry/Cargo.toml
@@ -15,10 +15,10 @@ rust-version.workspace = true
 
 [dependencies]
 fastrace = { workspace = true }
-futures = { workspace = true, features = ["executor"] }
 log = { workspace = true }
 opentelemetry = { version = "0.27", features = ["trace"] }
 opentelemetry_sdk = { version = "0.27", features = ["trace"] }
+pollster = { version = "0.4.0" }
 
 [dev-dependencies]
 opentelemetry-otlp = { version = "0.27", features = ["trace"] }

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -142,7 +142,7 @@ impl OpenTelemetryReporter {
 
     fn try_report(&mut self, spans: Vec<SpanRecord>) -> Result<(), Box<dyn std::error::Error>> {
         let spans = self.convert(spans);
-        futures::executor::block_on(self.exporter.export(spans))?;
+        pollster::block_on(self.exporter.export(spans))?;
         Ok(())
     }
 }

--- a/fastrace/Cargo.toml
+++ b/fastrace/Cargo.toml
@@ -36,7 +36,6 @@ fastrace-datadog = { workspace = true }
 fastrace-jaeger = { workspace = true }
 fastrace-opentelemetry = { workspace = true }
 flume = "0.11"
-futures = { workspace = true }
 futures-timer = "3"
 log = { workspace = true }
 logcall = "0.1"
@@ -45,6 +44,7 @@ mockall = "0.13"
 opentelemetry = { version = "0.27", features = ["trace"] }
 opentelemetry-otlp = { version = "0.27", features = ["trace"] }
 opentelemetry_sdk = { version = "0.27", features = ["trace"] }
+pollster = { version = "0.4.0" }
 rand = "0.9"
 rustracing = "0.6"
 serial_test = "3.1"

--- a/fastrace/benches/trace.rs
+++ b/fastrace/benches/trace.rs
@@ -119,7 +119,7 @@ fn bench_trace_future(c: &mut Criterion) {
         group.bench_function(len.to_string(), |b| {
             b.iter(|| {
                 let root = Span::root("root", SpanContext::new(TraceId(12), SpanId::default()));
-                futures::executor::block_on(f(*len).in_span(root));
+                pollster::block_on(f(*len).in_span(root));
             })
         });
     }

--- a/fastrace/src/lib.rs
+++ b/fastrace/src/lib.rs
@@ -264,7 +264,7 @@
 //! use fastrace::collector::Config;
 //! use fastrace::collector::ConsoleReporter;
 //! use fastrace::prelude::*;
-//! use futures::executor::block_on;
+//! use pollster::block_on;
 //!
 //! #[trace]
 //! fn do_something(i: u64) {

--- a/fastrace/tests/lib.rs
+++ b/fastrace/tests/lib.rs
@@ -8,7 +8,7 @@ use fastrace::collector::TestReporter;
 use fastrace::local::LocalCollector;
 use fastrace::prelude::*;
 use fastrace::util::tree::tree_str_from_span_records;
-use futures::executor::block_on;
+use pollster::block_on;
 use serial_test::serial;
 use tokio::runtime::Builder;
 


### PR DESCRIPTION
We don't need to depend on the whole `futures` crate for several cases.