### PR TITLE
chore: update benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest,cargo-nextest
+
       - name: Cargo version
         run: cargo --version
 
@@ -52,7 +56,7 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo test --workspace --all-targets -- --nocapture
+          cargo nextest run --workspace
           cargo test --doc
 
       - name: Run examples


### PR DESCRIPTION
Benchmark result on M4 MAX laptop:

```
compare              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ multi threads                   │               │               │               │         │
│  ├─ fastrace                     │               │               │               │         │
│  │  ├─ 1           116.9 µs      │ 7.088 ms      │ 160.6 µs      │ 230.2 µs      │ 100     │ 100
│  │  ├─ 10          120.5 µs      │ 251.9 µs      │ 134.6 µs      │ 138.2 µs      │ 100     │ 100
│  │  ├─ 100         115.2 µs      │ 243.1 µs      │ 154.2 µs      │ 161.3 µs      │ 100     │ 100
│  │  ├─ 1000        206.1 µs      │ 23.45 ms      │ 266.8 µs      │ 539.6 µs      │ 100     │ 100
│  │  ╰─ 10000       863.6 µs      │ 6.999 ms      │ 925.6 µs      │ 1.045 ms      │ 100     │ 100
│  ╰─ tokio_tracing                │               │               │               │         │
│     ├─ 1           119.4 µs      │ 241.9 µs      │ 159.9 µs      │ 164.7 µs      │ 100     │ 100
│     ├─ 10          126.8 µs      │ 274.7 µs      │ 146.9 µs      │ 157.8 µs      │ 100     │ 100
│     ├─ 100         311.6 µs      │ 500.6 µs      │ 339.3 µs      │ 348.1 µs      │ 100     │ 100
│     ├─ 1000        2.514 ms      │ 8.491 ms      │ 2.796 ms      │ 3.348 ms      │ 100     │ 100
│     ╰─ 10000       24.26 ms      │ 30.09 ms      │ 25.38 ms      │ 25.48 ms      │ 100     │ 100
╰─ single thread                   │               │               │               │         │
   ├─ fastrace                     │               │               │               │         │
   │  ├─ 1           165.7 ns      │ 10.74 µs      │ 208.7 ns      │ 359.7 ns      │ 100     │ 100
   │  ├─ 10          718.4 ns      │ 1.541 µs      │ 817.4 ns      │ 848.9 ns      │ 100     │ 800
   │  ├─ 100         5.874 µs      │ 9.666 µs      │ 6.582 µs      │ 6.842 µs      │ 100     │ 100
   │  ├─ 1000        57.12 µs      │ 109.7 µs      │ 68.41 µs      │ 68.71 µs      │ 100     │ 100
   │  ╰─ 10000       618.9 µs      │ 1.457 ms      │ 691.4 µs      │ 700.4 µs      │ 100     │ 100
   ╰─ tokio_tracing                │               │               │               │         │
      ├─ 1           915.7 ns      │ 25.33 µs      │ 1.083 µs      │ 1.355 µs      │ 100     │ 100
      ├─ 10          5.124 µs      │ 17.41 µs      │ 5.499 µs      │ 6.035 µs      │ 100     │ 100
      ├─ 100         50.79 µs      │ 99.66 µs      │ 55.49 µs      │ 56.66 µs      │ 100     │ 100
      ├─ 1000        446.7 µs      │ 866.8 µs      │ 514.6 µs      │ 519.5 µs      │ 100     │ 100
      ╰─ 10000       4.719 ms      │ 5.856 ms      │ 5.286 ms      │ 5.291 ms      │ 100     │ 100
```