### PR TITLE
Remove function name trimming from macro code

### DIFF
--- a/fastrace/src/macros.rs
+++ b/fastrace/src/macros.rs
@@ -46,8 +46,7 @@ macro_rules! func_path {
             std::any::type_name::<T>()
         }
         let name = type_name_of(f);
-        let name = &name[..name.len() - 3];
-        name.trim_end_matches("::{{closure}}")
+        &name[..name.len() - 3]
     }};
 }
 

--- a/fastrace/tests/lib.rs
+++ b/fastrace/tests/lib.rs
@@ -528,7 +528,7 @@ root []
     do_something_async_short_name []
     do_something_short_name []
     lib::macro_example::{{closure}}::do_something []
-    lib::macro_example::{{closure}}::do_something_async []
+    lib::macro_example::{{closure}}::do_something_async::{{closure}} []
 "#;
     assert_eq!(
         tree_str_from_span_records(collected_spans.lock().clone()),


### PR DESCRIPTION
We use `#[trace]` quite extensively throughout our codebase. A function `foo` could look like:

```rust
#[trace]
fn foo() {
    bar();
}
```

The `#[trace]` macro ends up expanding to:
```rust
fn foo() {
    let __guard__ = fastrace::local::LocalSpan::enter_with_local_parent({
        fn f() {}
        fn type_name_of<T>(_: T) -> &'static str {
            std::any::type_name::<T>()
        }
        let name = type_name_of(f);
        let name = &name[..name.len() - 3];
        name.trim_end_matches("::{{closure}}")
    });
    {
        bar();
    }
}
```

This `trim_end_matches` gets inserted everywhere, and it ends up calling several `Pattern` and `StrSeacher` realted
functions from the standard library. This trimming ends up being quite expensive and it compounds over the execution
of your program. Removing this name trimming has significantly improved performance in many of our workloads.

Here is a sample from the internal benchmarks of `fastrace`:

Trace benchmark before:
```
Timer precision: 41 ns
trace          fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ concurrent                │               │               │               │         │
│  ├─ 1        123.2 µs      │ 4.429 ms      │ 145.5 µs      │ 233.7 µs      │ 100     │ 100
│  ├─ 10       119.4 µs      │ 4.178 ms      │ 141.8 µs      │ 238.3 µs      │ 100     │ 100
│  ├─ 100      146.7 µs      │ 5.708 ms      │ 192.5 µs      │ 294.1 µs      │ 100     │ 100
│  ├─ 1000     972.6 µs      │ 67.59 ms      │ 1.041 ms      │ 1.773 ms      │ 100     │ 100
│  ╰─ 10000    9.318 ms      │ 63.63 ms      │ 10.17 ms      │ 10.94 ms      │ 100     │ 100
├─ deep                      │               │               │               │         │
│  ├─ 1        207.7 ns      │ 14.29 µs      │ 249.7 ns      │ 442.2 ns      │ 100     │ 100
│  ├─ 10       1.062 µs      │ 2.135 µs      │ 1.291 µs      │ 1.264 µs      │ 100     │ 400
│  ├─ 100      9.333 µs      │ 22.95 µs      │ 9.812 µs      │ 10.53 µs      │ 100     │ 100
│  ╰─ 1000     90.91 µs      │ 837.1 µs      │ 94.37 µs      │ 103.1 µs      │ 100     │ 100
├─ deep_raw                  │               │               │               │         │
│  ├─ 1        128.6 ns      │ 299.2 ns      │ 131.2 ns      │ 140.7 ns      │ 100     │ 3200
│  ├─ 10       1.072 µs      │ 1.801 µs      │ 1.114 µs      │ 1.187 µs      │ 100     │ 400
│  ├─ 100      9.249 µs      │ 12.37 µs      │ 9.457 µs      │ 9.686 µs      │ 100     │ 100
│  ╰─ 1000     90.49 µs      │ 181.3 µs      │ 93.08 µs      │ 95.38 µs      │ 100     │ 100
├─ future                    │               │               │               │         │
│  ├─ 1        116.9 ns      │ 257.5 ns      │ 129.9 ns      │ 141.9 ns      │ 100     │ 3200
│  ├─ 10       640.3 ns      │ 5.577 µs      │ 780.9 ns      │ 909.4 ns      │ 100     │ 800
│  ├─ 100      5.041 µs      │ 9.082 µs      │ 5.749 µs      │ 6.111 µs      │ 100     │ 100
│  ├─ 1000     46.33 µs      │ 66.45 µs      │ 50.64 µs      │ 50.49 µs      │ 100     │ 100
│  ╰─ 10000    457.3 µs      │ 981.3 µs      │ 510.7 µs      │ 525.6 µs      │ 100     │ 100
├─ wide                      │               │               │               │         │
│  ├─ 1        103.8 ns      │ 379.2 ns      │ 131.2 ns      │ 129.4 ns      │ 100     │ 6400
│  ├─ 10       947.7 ns      │ 5.145 µs      │ 1.077 µs      │ 1.194 µs      │ 100     │ 800
│  ├─ 100      8.29 µs       │ 14.37 µs      │ 9.249 µs      │ 9.513 µs      │ 100     │ 100
│  ├─ 1000     80.29 µs      │ 106.8 µs      │ 84.2 µs       │ 86.12 µs      │ 100     │ 100
│  ╰─ 10000    793 µs        │ 1.45 ms       │ 822.8 µs      │ 855.9 µs      │ 100     │ 100
╰─ wide_raw                  │               │               │               │         │
   ├─ 1        127.3 ns      │ 169 ns        │ 129.2 ns      │ 133.2 ns      │ 100     │ 3200
   ├─ 10       957.9 ns      │ 1.322 µs      │ 978.9 ns      │ 1.011 µs      │ 100     │ 400
   ├─ 100      7.999 µs      │ 10.91 µs      │ 8.332 µs      │ 8.814 µs      │ 100     │ 100
   ├─ 1000     77.99 µs      │ 101.3 µs      │ 80.22 µs      │ 81.39 µs      │ 100     │ 100
   ╰─ 10000    793.4 µs      │ 889.3 µs      │ 815.9 µs      │ 816.8 µs      │ 100     │ 100
```

Trace benchmark after:
```
Timer precision: 41 ns
trace          fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ concurrent                │               │               │               │         │
│  ├─ 1        122.8 µs      │ 3.672 ms      │ 141.2 µs      │ 191.1 µs      │ 100     │ 100
│  ├─ 10       121.9 µs      │ 4.968 ms      │ 147.5 µs      │ 258.2 µs      │ 100     │ 100
│  ├─ 100      145.2 µs      │ 3.598 ms      │ 190.1 µs      │ 234 µs        │ 100     │ 100
│  ├─ 1000     938.2 µs      │ 8.138 ms      │ 1.033 ms      │ 1.111 ms      │ 100     │ 100
│  ╰─ 10000    8.184 ms      │ 99.42 ms      │ 9.968 ms      │ 11.19 ms      │ 100     │ 100
├─ deep                      │               │               │               │         │
│  ├─ 1        165.7 ns      │ 9.707 µs      │ 207.7 ns      │ 300.5 ns      │ 100     │ 100
│  ├─ 10       635.1 ns      │ 1.557 µs      │ 770.6 ns      │ 777 ns        │ 100     │ 800
│  ├─ 100      5.207 µs      │ 10.45 µs      │ 6.416 µs      │ 6.652 µs      │ 100     │ 100
│  ╰─ 1000     49.37 µs      │ 60.58 µs      │ 51.87 µs      │ 52.51 µs      │ 100     │ 100
├─ deep_raw                  │               │               │               │         │
│  ├─ 1        90.85 ns      │ 165.1 ns      │ 92.2 ns       │ 98.93 ns      │ 100     │ 3200
│  ├─ 10       609.1 ns      │ 1.02 µs       │ 689.7 ns      │ 724.8 ns      │ 100     │ 800
│  ├─ 100      4.958 µs      │ 6.957 µs      │ 5.312 µs      │ 5.599 µs      │ 100     │ 100
│  ╰─ 1000     48.49 µs      │ 68.16 µs      │ 49.56 µs      │ 50.74 µs      │ 100     │ 100
├─ future                    │               │               │               │         │
│  ├─ 1        118.2 ns      │ 412.5 ns      │ 123.4 ns      │ 143.9 ns      │ 100     │ 3200
│  ├─ 10       655.9 ns      │ 2.15 µs       │ 731.4 ns      │ 801.3 ns      │ 100     │ 800
│  ├─ 100      5.082 µs      │ 10.08 µs      │ 5.499 µs      │ 5.743 µs      │ 100     │ 100
│  ├─ 1000     47.2 µs       │ 69.2 µs       │ 50.62 µs      │ 52.45 µs      │ 100     │ 100
│  ╰─ 10000    466.9 µs      │ 852.2 µs      │ 504.1 µs      │ 514.2 µs      │ 100     │ 100
├─ wide                      │               │               │               │         │
│  ├─ 1        103.2 ns      │ 199.6 ns      │ 132.8 ns      │ 131.6 ns      │ 100     │ 6400
│  ├─ 10       629.9 ns      │ 2.343 µs      │ 765.3 ns      │ 794.7 ns      │ 100     │ 800
│  ├─ 100      4.999 µs      │ 9.041 µs      │ 5.999 µs      │ 6.168 µs      │ 100     │ 100
│  ├─ 1000     47.91 µs      │ 316.4 µs      │ 50.79 µs      │ 55.26 µs      │ 100     │ 100
│  ╰─ 10000    464.2 µs      │ 1.163 ms      │ 509.9 µs      │ 527.3 µs      │ 100     │ 100
╰─ wide_raw                  │               │               │               │         │
   ├─ 1        89.57 ns      │ 134.4 ns      │ 92.5 ns       │ 98.1 ns       │ 100     │ 6400
   ├─ 10       588.2 ns      │ 1.077 µs      │ 624.7 ns      │ 665.3 ns      │ 100     │ 800
   ├─ 100      4.874 µs      │ 7.041 µs      │ 5.041 µs      │ 5.267 µs      │ 100     │ 100
   ├─ 1000     47.87 µs      │ 173.1 µs      │ 50.81 µs      │ 51.82 µs      │ 100     │ 100
   ╰─ 10000    434.8 µs      │ 566.9 µs      │ 485.7 µs      │ 489.8 µs      │ 100     │ 100
```

Since the goal of `fastrace` is to be first and foremost fast, I believe paying such a high price for purely aesthetic reasons (trimming "closure" out of a name) is not worth it, given all the speed gains you can get if you just take it out. This little change makes `fastrace` even faster!