### PR TITLE
feat: Support Google Cloud Trace as a reporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +126,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bon"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94054366e2ff97b455acdd4fdb03913f717febc57b7bbd1741b2c3b87efae030"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542a990e676ce0a0a895ae54b2d94afd012434f2228a85b186c6bc1a7056cdc6"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +173,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -142,6 +191,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -246,6 +308,51 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
 
 [[package]]
 name = "displaydoc"
@@ -414,6 +521,19 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project",
+ "tokio",
+]
+
+[[package]]
+name = "fastrace-google-cloud"
+version = "0.7.0"
+dependencies = [
+ "fastrace 0.7.9",
+ "google-cloud-rpc",
+ "google-cloud-trace-v2",
+ "google-cloud-wkt",
+ "log",
+ "opentelemetry-semantic-conventions",
  "tokio",
 ]
 
@@ -653,6 +773,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "google-cloud-auth"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e84ff396c00b469efa7f2c35cca5f1d159ee789f24d6533568a40e540cc373a"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bon",
+ "google-cloud-gax",
+ "http",
+ "reqwest",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdb2b8a3f3da8e4232df0df6f83fff01ab2acf95c8e722fc5f9c51b54b7c62a"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http",
+ "pin-project",
+ "rand 0.9.0",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db9c6fc51068baa033a34e8b6422419f79db9855afc54f968ec308696f3bac2"
+dependencies = [
+ "built",
+ "bytes",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "http",
+ "http-body-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4678537d3a80bdc47190d17c411968dc5e89e0cc670d3bdb72beb0aa21322a1"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-trace-v2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "594aa0fdef29551b6f2673f5870f0c107ff15006e5be021ba2adf758413ffe0f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "lazy_static",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8315fe9586810de1d7e98f08c49989a8f3de9abc94615e866d71764cca1379"
+dependencies = [
+ "base64",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +910,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -809,6 +1043,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +1219,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -965,6 +1230,7 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -1199,6 +1465,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1761,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1782,7 +2076,9 @@ version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1946,6 +2242,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.8.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,6 +2365,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2212,6 +2544,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2714,6 +3077,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1354,10 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+dependencies = [
+ "serde",
+ "value-bag",
+]
 
 [[package]]
 name = "logcall"
@@ -2209,6 +2223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_fmt"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2400,84 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sval"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9739f56c5d0c44a5ed45473ec868af02eb896af8c05f616673a31e1d1bb09"
+
+[[package]]
+name = "sval_buffer"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39b07436a8c271b34dad5070c634d1d3d76d6776e938ee97b4a66a5e8003d0b"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffcb072d857431bf885580dacecf05ed987bac931230736739a79051dbf3499b"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f214f427ad94a553e5ca5514c95c6be84667cbc5568cce957f03f3477d03d5c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ed34b32e638dec9a99c8ac92d0aa1220d40041026b625474c2b6a4d6f4feb"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14bae8fcb2f24fee2c42c1f19037707f7c9a29a0cda936d2188d48a961c4bb2a"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4eaea3821d3046dcba81d4b8489421da42961889902342691fb7eab491d79e"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172dd4aa8cb3b45c8ac8f3b4111d644cd26938b0643ede8f93070812b87fb339"
+dependencies = [
+ "serde",
+ "sval",
+ "sval_nested",
+]
 
 [[package]]
 name = "syn"
@@ -2880,6 +2981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3026,42 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35540706617d373b118d550d41f5dfe0b78a0c195dc13c6815e92e2638432306"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe7e140a2658cc16f7ee7a86e413e803fc8f9b5127adc8755c19f9fefa63a52"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "fastrace-macro",
   "fastrace-jaeger",
   "fastrace-datadog",
+  "fastrace-google-cloud",
   "fastrace-opentelemetry",
   "fastrace-futures",
   "test-statically-disable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ fastrace-jaeger = { path = "fastrace-jaeger" }
 fastrace-opentelemetry = { path = "fastrace-opentelemetry" }
 
 # crates.io dependencies
-log = { version = "0.4" }
+log = { version = "0.4", features = ["kv_serde"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [profile.bench]

--- a/fastrace-google-cloud/Cargo.toml
+++ b/fastrace-google-cloud/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "fastrace-google-cloud"
+version = "0.7.0"
+
+categories = ["development-tools::debugging"]
+description = "Google Cloud Monitoring reporter for fastrace"
+documentation = "https://docs.rs/fastrace-google-cloud"
+keywords = ["tracing", "span", "google-cloud", "stackdriver"]
+readme = "README.md"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+fastrace = { workspace = true }
+google-cloud-rpc = "0.2.0"
+google-cloud-trace-v2 = "0.2.0"
+google-cloud-wkt = "0.3.0"
+log = { workspace = true }
+opentelemetry-semantic-conventions = { version = "0.29.0", features = ["semconv_experimental"] }
+tokio = { version = "1.44.2", default-features = false, features = ["rt"] }

--- a/fastrace-google-cloud/README.md
+++ b/fastrace-google-cloud/README.md
@@ -1,0 +1,44 @@
+# fastrace-google-cloud
+
+[![Documentation](https://docs.rs/fastrace-google-cloud/badge.svg)](https://docs.rs/fastrace-google-cloud/)
+[![Crates.io](https://img.shields.io/crates/v/fastrace-google-cloud.svg)](https://crates.io/crates/fastrace-google-cloud)
+[![LICENSE](https://img.shields.io/github/license/fast/fastrace.svg)](https://github.com/fast/fastrace/blob/main/LICENSE)
+
+[Datadog](https://docs.datadoghq.com/tracing/) reporter for [`fastrace`](https://crates.io/crates/fastrace).
+
+## Dependencies
+
+```toml
+[dependencies]
+fastrace = "0.7"
+fastrace-google-cloud = "0.7"
+google-cloud-trace-v2 = "0.2.0"
+```
+
+## Report to Google Cloud Trace
+
+```rust
+use std::net::SocketAddr;
+
+use fastrace::collector::Config;
+use fastrace::prelude::*;
+use google_cloud_trace_v2::model::span::SpanKind;
+use google_cloud_trace_v2::client::TraceService;
+
+# async fn run_trace() {
+// Initialize reporter
+let trace_service = TraceService::builder().build().await.unwrap();
+let reporter = fastrace_google_cloud::GoogleCloudReporter::new(
+    trace_service,
+    "project-id".to_string(),
+);
+fastrace::set_reporter(reporter, Config::default());
+
+{
+    // Start tracing
+    let root = Span::root("root", SpanContext::random());
+}
+
+fastrace::flush();
+# }
+```

--- a/fastrace-google-cloud/src/lib.rs
+++ b/fastrace-google-cloud/src/lib.rs
@@ -192,10 +192,15 @@ impl GoogleCloudReporter {
     }
 
     fn try_report(&self, spans: Vec<SpanRecord>) -> google_cloud_trace_v2::Result<()> {
+        let spans = spans
+            .into_iter()
+            .map(|s| self.convert_span(s))
+            .collect::<Vec<_>>();
+        log::error!(spans:serde; "Reporting these spans");
         self.tokio_runtime.block_on(
             self.client
                 .batch_write_spans(format!("projects/{}", self.trace_project_id))
-                .set_spans(spans.into_iter().map(|s| self.convert_span(s)))
+                .set_spans(spans)
                 .send(),
         )
     }

--- a/fastrace-google-cloud/src/lib.rs
+++ b/fastrace-google-cloud/src/lib.rs
@@ -1,0 +1,256 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![doc = include_str!("../README.md")]
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use fastrace::collector::{EventRecord, Reporter};
+use fastrace::prelude::*;
+use google_cloud_rpc::model::Status;
+use google_cloud_trace_v2::client::TraceService;
+use google_cloud_trace_v2::model::span::time_event::Annotation;
+use google_cloud_trace_v2::model::span::{Attributes, SpanKind, TimeEvent, TimeEvents};
+use google_cloud_trace_v2::model::{
+    AttributeValue, Span as GoogleSpan, StackTrace, TruncatableString,
+};
+use google_cloud_wkt::Timestamp;
+use opentelemetry_semantic_conventions::attribute as attribute_sem;
+
+pub struct GoogleCloudReporter {
+    tokio_runtime: std::sync::LazyLock<tokio::runtime::Runtime>,
+    client: TraceService,
+    trace_project_id: String,
+    attribute_name_mappings: Option<HashMap<&'static str, &'static str>>,
+    status_converter: fn(&SpanRecord, &mut HashMap<String, AttributeValue>) -> Option<Status>,
+    span_kind_converter: fn(&SpanRecord, &mut HashMap<String, AttributeValue>) -> SpanKind,
+    stack_trace_converter:
+        fn(&SpanRecord, &mut HashMap<String, AttributeValue>) -> Option<StackTrace>,
+}
+
+pub fn opentelemetry_semantic_mapping() -> HashMap<&'static str, &'static str> {
+    HashMap::from([
+        (attribute_sem::OTEL_COMPONENT_TYPE, "/component"),
+        (attribute_sem::EXCEPTION_MESSAGE, "/error/message"),
+        (attribute_sem::EXCEPTION_MESSAGE, "/error/name"),
+        (
+            attribute_sem::NETWORK_PROTOCOL_VERSION,
+            "/http/client_protocol",
+        ),
+        (attribute_sem::HTTP_HOST, "/http/host"),
+        (attribute_sem::HTTP_METHOD, "/http/method"),
+        (attribute_sem::HTTP_REQUEST_METHOD, "/http/method"),
+        // Not a standard OTEL attribute, but some existing systems have this mapping
+        ("http.path", "/http/path"),
+        (attribute_sem::URL_PATH, "/http/path"),
+        (attribute_sem::HTTP_REQUEST_SIZE, "/http/request/size"),
+        (attribute_sem::HTTP_RESPONSE_SIZE, "/http/response/size"),
+        (attribute_sem::HTTP_ROUTE, "/http/route"),
+        (
+            attribute_sem::HTTP_RESPONSE_STATUS_CODE,
+            "/http/status_code",
+        ),
+        (attribute_sem::HTTP_STATUS_CODE, "/http/status_code"),
+        (attribute_sem::HTTP_USER_AGENT, "/http/user_agent"),
+        (attribute_sem::USER_AGENT_ORIGINAL, "/http/user_agent"),
+        (
+            attribute_sem::K8S_CLUSTER_NAME,
+            "g.co/r/k8s_container/cluster_name",
+        ),
+        (
+            attribute_sem::K8S_NAMESPACE_NAME,
+            "g.co/r/k8s_container/namespace",
+        ),
+        (attribute_sem::K8S_POD_NAME, "g.co/r/k8s_container/pod_name"),
+        (
+            attribute_sem::K8S_CONTAINER_NAME,
+            "g.co/r/k8s_container/container_name",
+        ),
+    ])
+}
+
+impl GoogleCloudReporter {
+    pub fn new(client: TraceService, trace_project_id: String) -> Self {
+        Self {
+            tokio_runtime: LazyLock::new(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_io()
+                    .enable_time()
+                    .build()
+                    .unwrap()
+            }),
+            client,
+            trace_project_id,
+            attribute_name_mappings: None,
+            status_converter: |_, _| None,
+            span_kind_converter: |_, attribute_map| {
+                let span_kind = attribute_map.remove("span.kind");
+
+                span_kind
+                    .as_ref()
+                    .and_then(|value| value.string_value())
+                    .and_then(|s| SpanKind::from_str_name(&s.value))
+                    .unwrap_or(SpanKind::INTERNAL)
+            },
+            stack_trace_converter: |_, _| None,
+        }
+    }
+
+    pub fn attribute_name_mappings(
+        mut self,
+        attribute_name_mappings: Option<HashMap<&'static str, &'static str>>,
+    ) -> Self {
+        self.attribute_name_mappings = attribute_name_mappings;
+        self
+    }
+
+    pub fn status_converter(
+        mut self,
+        status_converter: fn(&SpanRecord, &mut HashMap<String, AttributeValue>) -> Option<Status>,
+    ) -> Self {
+        self.status_converter = status_converter;
+        self
+    }
+
+    pub fn span_kind_converter(
+        mut self,
+        span_kind_converter: fn(&SpanRecord, &mut HashMap<String, AttributeValue>) -> SpanKind,
+    ) -> Self {
+        self.span_kind_converter = span_kind_converter;
+        self
+    }
+
+    pub fn stack_trace_converter(
+        mut self,
+        stack_trace_converter: fn(
+            &SpanRecord,
+            &mut HashMap<String, AttributeValue>,
+        ) -> Option<StackTrace>,
+    ) -> Self {
+        self.stack_trace_converter = stack_trace_converter;
+        self
+    }
+
+    fn convert_span(&self, span: SpanRecord) -> GoogleSpan {
+        let span_id = convert_span_id(span.span_id);
+
+        let mut attributes =
+            convert_properties(&span.properties, self.attribute_name_mappings.as_ref());
+        let status = (self.status_converter)(&span, &mut attributes.attribute_map);
+        let span_kind = (self.span_kind_converter)(&span, &mut attributes.attribute_map);
+        let stack_trace = (self.stack_trace_converter)(&span, &mut attributes.attribute_map);
+
+        let mut google_span = GoogleSpan::new()
+            .set_name(format!(
+                "projects/{}/traces/{:016x}/spans/{}",
+                self.trace_project_id, span.trace_id.0, span_id
+            ))
+            .set_span_id(span_id)
+            .set_display_name(TruncatableString::new().set_value(span.name))
+            .set_start_time(convert_unix_ns(span.begin_time_unix_ns))
+            .set_end_time(convert_unix_ns(span.begin_time_unix_ns + span.duration_ns))
+            .set_attributes(attributes)
+            .set_status(status)
+            .set_span_kind(span_kind)
+            .set_stack_trace(stack_trace)
+            .set_time_events(
+                TimeEvents::new()
+                    .set_time_event(span.events.into_iter().map(|e| self.convert_event(e))),
+            );
+
+        if let Some(parent_span_id) = convert_parent_span_id(span.parent_id) {
+            google_span = google_span.set_parent_span_id(parent_span_id);
+        }
+
+        google_span
+    }
+
+    fn convert_event(&self, event: EventRecord) -> TimeEvent {
+        TimeEvent::new()
+            .set_time(convert_unix_ns(event.timestamp_unix_ns))
+            .set_annotation(
+                Annotation::new()
+                    .set_attributes(convert_properties(
+                        &event.properties,
+                        self.attribute_name_mappings.as_ref(),
+                    ))
+                    .set_description(TruncatableString::new().set_value(event.name)),
+            )
+    }
+
+    fn try_report(&self, spans: Vec<SpanRecord>) -> google_cloud_trace_v2::Result<()> {
+        self.tokio_runtime.block_on(
+            self.client
+                .batch_write_spans(format!("projects/{}", self.trace_project_id))
+                .set_spans(spans.into_iter().map(|s| self.convert_span(s)))
+                .send(),
+        )
+    }
+}
+
+impl Reporter for GoogleCloudReporter {
+    fn report(&mut self, spans: Vec<SpanRecord>) {
+        if spans.is_empty() {
+            return;
+        }
+
+        if let Err(err) = self.try_report(spans) {
+            log::error!("report to Google Cloud Trace failed: {}", err);
+        }
+    }
+}
+
+fn convert_properties(
+    properties: &[(Cow<'static, str>, Cow<'static, str>)],
+    attribute_name_mappings: Option<&HashMap<&'static str, &'static str>>,
+) -> Attributes {
+    let attributes = properties.iter().map(|(k, v)| {
+        let key = attribute_name_mappings
+            .as_ref()
+            .and_then(|m| m.get(k.as_ref()).cloned())
+            .unwrap_or(k.as_ref());
+        (
+            key.to_string(),
+            AttributeValue::new()
+                .set_string_value(TruncatableString::new().set_value(v.to_string())),
+        )
+    });
+
+    Attributes::new().set_attribute_map(attributes)
+}
+
+fn convert_unix_ns(unix_time: u64) -> Timestamp {
+    Timestamp::clamp(
+        (unix_time / 1_000_000_000) as i64,
+        (unix_time % 1_000_000_000) as i32,
+    )
+}
+
+/// Convert a span ID to a string representation.
+fn convert_span_id(span_id: SpanId) -> String {
+    format!("{:08x}", span_id.0)
+}
+
+/// Convert a parent span ID to a string representation.
+///
+/// Returns `None` if the parent span ID is invalid (zero).
+fn convert_parent_span_id(span_id: SpanId) -> Option<String> {
+    if span_id.0 == 0 {
+        None
+    } else {
+        Some(convert_span_id(span_id))
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.85.0"
 components = ["cargo", "rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
This is a draft of an implementation supporting Google Cloud Trace as a reporter. I'd like to know if the code is of interest before I do more work on it. It should be functional as is, but needs review, documentation, etc.

Basic idea: it uses the upcoming official Google Cloud APIs to directly push to Google Cloud Trace, without going through OpenTelemetry. This can more directly support the intersection of features between fastrace and GCP Trace. Also, I always find configuring OT is a bit like pulling teeth, so this greatly simplifies the setup story.

Some extra features over current reporters:
 - Function provided to allow customization of the calculation of span kind, span status, and stack trace information, depending on user requirements; this matches the need to calculate values for fields particular to Google's API.
  
Some possible issues (at this point):
 - Google API is not stable (but then, is it less stable than OpenTelemetry?)
 - It seems to need rust 1.85.0 (edition 2024) to compile, so it'll either need different minimum rust version (and the complexity that goes along with that), or wait until fastrace is okay with bumping to that version
 - Not certain about the optimal way to set up a tokio runtime (needed for reqwest). Here, I use a `LazyLock` and set up a current thread runtime, initialized in `try_report`.