### PR TITLE
Add #[allow(unreachable_code)] to output_ty_hint __ret__

### DIFF
--- a/fastrace-macro/src/lib.rs
+++ b/fastrace-macro/src/lib.rs
@@ -402,6 +402,7 @@ fn gen_block(
                     #crate_path::future::FutureExt::in_span(
                         async move {
                             let __ret__: #output_ty_hint = #block;
+                            #[allow(unreachable_code)]
                             __ret__
                         },
                         __span__,

--- a/tests/macros/tests/ui/ok/async-in-trait.rs
+++ b/tests/macros/tests/ui/ok/async-in-trait.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 trait MyTrait {
     async fn work(&self) -> usize;
 }


### PR DESCRIPTION
This prevents unreachable code warnings when the body of the async block is divergent.
This happens in the test suite when calling `unimplemented!()` but it also happens in practice for infinite loops with early `return`s.