### PR TITLE
feat: preserve input tokens more carefully in #[trace]

### DIFF
--- a/tests/macros/tests/ui/err/properties-partial-escape.stderr
+++ b/tests/macros/tests/ui/err/properties-partial-escape.stderr
@@ -1,8 +1,7 @@
 error: invalid format string: unmatched `}` found
- --> tests/ui/err/properties-partial-escape.rs:3:1
+ --> tests/ui/err/properties-partial-escape.rs:3:33
   |
 3 | #[trace(properties = { "a": "{{b}" })]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in format string
+  |                                 ^ unmatched `}` in format string
   |
   = note: if you intended to print `}`, you can escape it using `}}`
-  = note: this error originates in the attribute macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Avoid using `block.span()` as the span for `quote_spanned!` - instead preserve input spans if appropriate or else point at the macro.

For simplicity I've replaced `unescape_format_string` with a generated `Arguments::as_str()` call, which lets us access a `&'static str` from a format string when it doesn't interpolate anything. This gives a better error message for invalid format strings, and in practice should be equivalent as the static-ness is known at compile time.