### PR TITLE
chore: release fastrace-opentelemetry v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "fastrace-opentelemetry"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "fastrace 0.7.17",
  "log",

--- a/fastrace-opentelemetry/CHANGELOG.md
+++ b/fastrace-opentelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All significant changes to this project will be documented in this file.
 
+## Unreleased
+
 ## v0.17.0
 
 ### Notable Changes

--- a/fastrace-opentelemetry/CHANGELOG.md
+++ b/fastrace-opentelemetry/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All significant changes to this project will be documented in this file.
 
-## Unreleased
+## v0.17.0
+
+### Notable Changes
+
+* Upgraded MSRV to 1.85 and Edition to 2024.
 
 ### New Features
 

--- a/fastrace-opentelemetry/Cargo.toml
+++ b/fastrace-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastrace-opentelemetry"
-version = "0.16.0"
+version = "0.17.0"
 
 categories = ["development-tools::debugging"]
 description = "Opentelemetry reporter for fastrace"


### PR DESCRIPTION
## Summary

- Release `fastrace-opentelemetry` v0.17.0.
- Include `OpenTelemetryReporter::with_block_on()` and the inherited MSRV 1.85 / Edition 2024 update in the release changelog.
