### PR TITLE
refactor!: clean up trace context ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All significant changes to this project will be documented in this file.
 ### Notable Changes
 
 - Upgrade MSRV to 1.85 and Edition to 2024.
-- Reworked trace propagation for 0.8: `TraceId` and `SpanId` are now checked opaque ids,
-  root parents use `Option<SpanId>` instead of all-zero ids, and `SpanContext` now carries the W3C
-  value model with explicit `TraceFlags` and pass-through `TraceState`.
+- Reworked trace propagation for 0.8: `TraceId` and `SpanId` are now opaque ids with explicit
+  `INVALID` values, root parents use `Option<SpanId>` instead of all-zero ids, and `SpanContext`
+  now carries the W3C value model with explicit `TraceFlags` and pass-through `TraceState`.
 
 ## v0.7.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All significant changes to this project will be documented in this file.
 
 - Upgrade MSRV to 1.85 and Edition to 2024.
 - Reworked trace propagation for 0.8: `TraceId` and `SpanId` are now opaque ids with explicit
-  `INVALID` values, root parents use `Option<SpanId>` instead of all-zero ids, and `SpanContext`
-  now carries the W3C value model with explicit `TraceFlags` and pass-through `TraceState`.
+  checked constructors, root parents use `Option<SpanId>` instead of all-zero ids, and
+  `SpanContext` now carries the W3C value model with explicit `TraceFlags` and pass-through
+  `TraceState`.
 
 ## v0.7.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All significant changes to this project will be documented in this file.
 ### Notable Changes
 
 - Upgrade MSRV to 1.85 and Edition to 2024.
-- Reworked trace propagation for 0.8: `TraceId` and `SpanId` are now opaque ids with explicit
-  checked constructors, root parents use `Option<SpanId>` instead of all-zero ids, and
-  `SpanContext` now carries the W3C value model with explicit `TraceFlags` and pass-through
-  `TraceState`.
+- Reworked trace propagation for 0.8: `TraceId` and `SpanId` are now opaque ids with checked
+  `from_bytes` and `from_hex` constructors returning `Option`, `FromStr` is removed, root parents
+  use `Option<SpanId>` instead of all-zero ids, and `SpanContext` now carries the W3C value model
+  with explicit `TraceFlags` and pass-through `TraceState`.
 
 ## v0.7.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All significant changes to this project will be documented in this file.
 ### Notable Changes
 
 - Upgrade MSRV to 1.85 and Edition to 2024.
+- Reworked trace propagation for 0.8: `TraceId` and `SpanId` are now checked opaque ids,
+  root parents use `Option<SpanId>` instead of all-zero ids, and `SpanContext` now carries the W3C
+  value model with explicit `TraceFlags` and pass-through `TraceState`.
 
 ## v0.7.17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "rand 0.10.0",
  "rtrb",
  "serde",
+ "serde_json",
  "serial_test",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ let tracestate_header = outgoing
     .map(|value| (SpanContext::TRACESTATE_HEADER_NAME, value));
 ```
 
-`TraceId` and `SpanId` are checked values. Construct them with `from_bytes`, `from_hex`, or
-`FromStr`. Hex input may be shorter than the full id width and is left-padded with zeroes;
-empty, too-long, malformed, and all-zero ids are rejected.
+`TraceId` and `SpanId` are opaque values. Construct them with `from_bytes`, `from_hex`, or
+`FromStr`. Hex input may be shorter than the full id width and is left-padded with zeroes.
+All-zero ids are represented as `TraceId::INVALID` and `SpanId::INVALID`; W3C `traceparent`
+decode and encode reject those invalid ids.
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -127,14 +127,11 @@ let _guard = root.set_local_parent();
 let outgoing = SpanContext::from_span(&root)
     .unwrap()
     .with_trace_state(incoming.trace_state.as_header_value().unwrap());
-let traceparent_header = (
-    SpanContext::TRACEPARENT_HEADER_NAME,
-    outgoing.encode_traceparent().unwrap(),
-);
+let traceparent_header = ("traceparent", outgoing.encode_traceparent().unwrap());
 let tracestate_header = outgoing
     .trace_state
     .as_header_value()
-    .map(|value| (SpanContext::TRACESTATE_HEADER_NAME, value));
+    .map(|value| ("tracestate", value));
 ```
 
 `TraceId` and `SpanId` are opaque values. Construct them with `from_bytes` or `from_hex`.

--- a/README.md
+++ b/README.md
@@ -124,13 +124,16 @@ let incoming =
 let root = Span::root("request", incoming.clone());
 let _guard = root.set_local_parent();
 
-let outgoing = SpanContext::from_span(&root).unwrap().with_trace_state(incoming.trace_state().unwrap());
+let outgoing = SpanContext::from_span(&root)
+    .unwrap()
+    .with_trace_state(incoming.trace_state.as_header_value().unwrap());
 let traceparent_header = (
     SpanContext::TRACEPARENT_HEADER_NAME,
     outgoing.encode_traceparent().unwrap(),
 );
 let tracestate_header = outgoing
-    .trace_state()
+    .trace_state
+    .as_header_value()
     .map(|value| (SpanContext::TRACESTATE_HEADER_NAME, value));
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ let tracestate_header = outgoing
 
 `TraceId` and `SpanId` are opaque values. Construct them with `from_bytes`, `from_hex`, or
 `FromStr`. Hex input may be shorter than the full id width and is left-padded with zeroes.
-All-zero ids are represented as `TraceId::INVALID` and `SpanId::INVALID`; W3C `traceparent`
-decode and encode reject those invalid ids.
+All-zero ids are rejected by checked constructors and W3C `traceparent` decoding.
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ let tracestate_header = outgoing
     .map(|value| (SpanContext::TRACESTATE_HEADER_NAME, value));
 ```
 
-`TraceId` and `SpanId` are opaque values. Construct them with `from_bytes`, `from_hex`, or
-`FromStr`. Hex input may be shorter than the full id width and is left-padded with zeroes.
+`TraceId` and `SpanId` are opaque values. Construct them with `from_bytes` or `from_hex`.
+Hex input may be shorter than the full id width and is left-padded with zeroes.
 All-zero ids are rejected by checked constructors and W3C `traceparent` decoding.
 
 ## Integrations

--- a/README.md
+++ b/README.md
@@ -103,6 +103,41 @@ Fastrace supports multiple out-of-box reporters to export spans:
 - [`fastrace-datadog`](https://crates.io/crates/fastrace-datadog): Export spans to [Datadog](https://www.datadoghq.com/)
 - [`fastrace-opentelemetry`](https://crates.io/crates/fastrace-opentelemetry): Export spans to [OpenTelemetry](https://opentelemetry.io/)
 
+## W3C Trace Context
+
+`Span` is the live timed span. `SpanContext` is the cheap parent or link context used by fastrace
+internally and at W3C propagation boundaries. It can parse and format `traceparent` values and
+carry a pass-through `tracestate` value, while the surrounding carrier shape is left to HTTP,
+gRPC, or message-queue integration code.
+
+Use `SpanContext::random()` for a new root without a remote parent. Use
+`SpanContext::decode_traceparent()` when extracting an incoming W3C `traceparent` value:
+
+```rust
+use fastrace::prelude::*;
+
+let incoming =
+    SpanContext::decode_traceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+        .unwrap()
+        .with_trace_state("vendor=value");
+
+let root = Span::root("request", incoming.clone());
+let _guard = root.set_local_parent();
+
+let outgoing = SpanContext::from_span(&root).unwrap().with_trace_state(incoming.trace_state().unwrap());
+let traceparent_header = (
+    SpanContext::TRACEPARENT_HEADER_NAME,
+    outgoing.encode_traceparent().unwrap(),
+);
+let tracestate_header = outgoing
+    .trace_state()
+    .map(|value| (SpanContext::TRACESTATE_HEADER_NAME, value));
+```
+
+`TraceId` and `SpanId` are checked values. Construct them with `from_bytes`, `from_hex`, or
+`FromStr`. Hex input may be shorter than the full id width and is left-padded with zeroes;
+empty, too-long, malformed, and all-zero ids are rejected.
+
 ## Integrations
 
 Fastrace provides integrations with popular libraries to handle context propagation automatically:

--- a/fastrace-datadog/src/lib.rs
+++ b/fastrace-datadog/src/lib.rs
@@ -54,9 +54,9 @@ impl DatadogReporter {
                     )
                 },
                 error_code: 0,
-                span_id: s.span_id.0,
-                trace_id: s.trace_id.0 as u64,
-                parent_id: s.parent_id.0,
+                span_id: datadog_span_id(s.span_id),
+                trace_id: trace_id_low(s.trace_id),
+                parent_id: s.parent_id.map_or(0, datadog_span_id),
             })
             .collect()
     }
@@ -108,4 +108,13 @@ struct DatadogSpan<'a> {
     span_id: u64,
     trace_id: u64,
     parent_id: u64,
+}
+
+fn trace_id_low(trace_id: TraceId) -> u64 {
+    let bytes = trace_id.to_bytes();
+    u64::from_be_bytes(bytes[8..].try_into().expect("trace id has 16 bytes"))
+}
+
+fn datadog_span_id(span_id: SpanId) -> u64 {
+    u64::from_be_bytes(span_id.to_bytes())
 }

--- a/fastrace-datadog/src/lib.rs
+++ b/fastrace-datadog/src/lib.rs
@@ -36,27 +36,34 @@ impl DatadogReporter {
     fn convert<'a>(&'a self, spans: &'a [SpanRecord]) -> Vec<DatadogSpan<'a>> {
         spans
             .iter()
-            .map(move |s| DatadogSpan {
-                name: &s.name,
-                service: &self.service_name,
-                trace_type: &self.trace_type,
-                resource: &self.resource,
-                start: s.begin_time_unix_ns as i64,
-                duration: s.duration_ns as i64,
-                meta: if s.properties.is_empty() {
-                    None
-                } else {
-                    Some(
-                        s.properties
-                            .iter()
-                            .map(|(k, v)| (k.as_ref(), v.as_ref()))
-                            .collect(),
-                    )
-                },
-                error_code: 0,
-                span_id: datadog_span_id(s.span_id),
-                trace_id: trace_id_low(s.trace_id),
-                parent_id: s.parent_id.map_or(0, datadog_span_id),
+            .map(move |s| {
+                let trace_id = s.trace_id.to_bytes();
+                DatadogSpan {
+                    name: &s.name,
+                    service: &self.service_name,
+                    trace_type: &self.trace_type,
+                    resource: &self.resource,
+                    start: s.begin_time_unix_ns as i64,
+                    duration: s.duration_ns as i64,
+                    meta: if s.properties.is_empty() {
+                        None
+                    } else {
+                        Some(
+                            s.properties
+                                .iter()
+                                .map(|(k, v)| (k.as_ref(), v.as_ref()))
+                                .collect(),
+                        )
+                    },
+                    error_code: 0,
+                    span_id: u64::from_be_bytes(s.span_id.to_bytes()),
+                    trace_id: u64::from_be_bytes(
+                        trace_id[8..].try_into().expect("trace id has 16 bytes"),
+                    ),
+                    parent_id: s
+                        .parent_id
+                        .map_or(0, |parent_id| u64::from_be_bytes(parent_id.to_bytes())),
+                }
             })
             .collect()
     }
@@ -108,13 +115,4 @@ struct DatadogSpan<'a> {
     span_id: u64,
     trace_id: u64,
     parent_id: u64,
-}
-
-fn trace_id_low(trace_id: TraceId) -> u64 {
-    let bytes = trace_id.to_bytes();
-    u64::from_be_bytes(bytes[8..].try_into().expect("trace id has 16 bytes"))
-}
-
-fn datadog_span_id(span_id: SpanId) -> u64 {
-    u64::from_be_bytes(span_id.to_bytes())
 }

--- a/fastrace-jaeger/src/lib.rs
+++ b/fastrace-jaeger/src/lib.rs
@@ -52,12 +52,18 @@ impl JaegerReporter {
         spans
             .iter()
             .map(move |s| {
-                let (trace_id_high, trace_id_low) = trace_id_halves(s.trace_id);
+                let trace_id = s.trace_id.to_bytes();
                 JaegerSpan {
-                    trace_id_high,
-                    trace_id_low,
-                    span_id: span_id_to_i64(s.span_id),
-                    parent_span_id: s.parent_id.map_or(0, span_id_to_i64),
+                    trace_id_high: i64::from_be_bytes(
+                        trace_id[..8].try_into().expect("trace id has 16 bytes"),
+                    ),
+                    trace_id_low: i64::from_be_bytes(
+                        trace_id[8..].try_into().expect("trace id has 16 bytes"),
+                    ),
+                    span_id: i64::from_be_bytes(s.span_id.to_bytes()),
+                    parent_span_id: s
+                        .parent_id
+                        .map_or(0, |parent_id| i64::from_be_bytes(parent_id.to_bytes())),
                     operation_name: s.name.to_string(),
                     references: vec![],
                     flags: 1,
@@ -133,17 +139,6 @@ impl JaegerReporter {
 
         Ok(())
     }
-}
-
-fn trace_id_halves(trace_id: TraceId) -> (i64, i64) {
-    let bytes = trace_id.to_bytes();
-    let high = i64::from_be_bytes(bytes[..8].try_into().expect("trace id has 16 bytes"));
-    let low = i64::from_be_bytes(bytes[8..].try_into().expect("trace id has 16 bytes"));
-    (high, low)
-}
-
-fn span_id_to_i64(span_id: SpanId) -> i64 {
-    i64::from_be_bytes(span_id.to_bytes())
 }
 
 impl Reporter for JaegerReporter {

--- a/fastrace-jaeger/src/lib.rs
+++ b/fastrace-jaeger/src/lib.rs
@@ -51,39 +51,42 @@ impl JaegerReporter {
     fn convert(&self, spans: &[SpanRecord]) -> Vec<JaegerSpan> {
         spans
             .iter()
-            .map(move |s| JaegerSpan {
-                trace_id_high: (s.trace_id.0 >> 64) as i64,
-                trace_id_low: s.trace_id.0 as i64,
-                span_id: s.span_id.0 as i64,
-                parent_span_id: s.parent_id.0 as i64,
-                operation_name: s.name.to_string(),
-                references: vec![],
-                flags: 1,
-                start_time: (s.begin_time_unix_ns / 1_000) as i64,
-                duration: (s.duration_ns / 1_000) as i64,
-                tags: s
-                    .properties
-                    .iter()
-                    .map(|(k, v)| Tag::String {
-                        key: k.to_string(),
-                        value: v.to_string(),
-                    })
-                    .collect(),
-                logs: s
-                    .events
-                    .iter()
-                    .map(|event| Log {
-                        timestamp: (event.timestamp_unix_ns / 1_000) as i64,
-                        fields: [("name".into(), event.name.clone())]
-                            .iter()
-                            .chain(&event.properties)
-                            .map(|(k, v)| Tag::String {
-                                key: k.to_string(),
-                                value: v.to_string(),
-                            })
-                            .collect(),
-                    })
-                    .collect(),
+            .map(move |s| {
+                let (trace_id_high, trace_id_low) = trace_id_halves(s.trace_id);
+                JaegerSpan {
+                    trace_id_high,
+                    trace_id_low,
+                    span_id: span_id_to_i64(s.span_id),
+                    parent_span_id: s.parent_id.map_or(0, span_id_to_i64),
+                    operation_name: s.name.to_string(),
+                    references: vec![],
+                    flags: 1,
+                    start_time: (s.begin_time_unix_ns / 1_000) as i64,
+                    duration: (s.duration_ns / 1_000) as i64,
+                    tags: s
+                        .properties
+                        .iter()
+                        .map(|(k, v)| Tag::String {
+                            key: k.to_string(),
+                            value: v.to_string(),
+                        })
+                        .collect(),
+                    logs: s
+                        .events
+                        .iter()
+                        .map(|event| Log {
+                            timestamp: (event.timestamp_unix_ns / 1_000) as i64,
+                            fields: [("name".into(), event.name.clone())]
+                                .iter()
+                                .chain(&event.properties)
+                                .map(|(k, v)| Tag::String {
+                                    key: k.to_string(),
+                                    value: v.to_string(),
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                }
             })
             .collect()
     }
@@ -130,6 +133,17 @@ impl JaegerReporter {
 
         Ok(())
     }
+}
+
+fn trace_id_halves(trace_id: TraceId) -> (i64, i64) {
+    let bytes = trace_id.to_bytes();
+    let high = i64::from_be_bytes(bytes[..8].try_into().expect("trace id has 16 bytes"));
+    let low = i64::from_be_bytes(bytes[8..].try_into().expect("trace id has 16 bytes"));
+    (high, low)
+}
+
+fn span_id_to_i64(span_id: SpanId) -> i64 {
+    i64::from_be_bytes(span_id.to_bytes())
 }
 
 impl Reporter for JaegerReporter {

--- a/fastrace-opentelemetry/README.md
+++ b/fastrace-opentelemetry/README.md
@@ -101,13 +101,11 @@ use fastrace_opentelemetry::current_opentelemetry_context;
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::Context;
 
-fn main() {
-    let span = Span::root("root", SpanContext::random());
-    let _guard = span.set_local_parent();
+let span = Span::root("root", SpanContext::random());
+let _guard = span.set_local_parent();
 
-    let _otel_guard = current_opentelemetry_context()
-        .map(|cx| Context::current().with_remote_span_context(cx).attach());
+let _otel_guard = current_opentelemetry_context()
+    .map(|cx| Context::current().with_remote_span_context(cx).attach());
 
-    // Call library code that uses `Context::current()`.
-}
+// Call library code that uses `Context::current()`.
 ```

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -114,14 +114,14 @@ pub struct OpenTelemetryReporter {
 pub fn current_opentelemetry_context() -> Option<OtelSpanContext> {
     let span_context = fastrace::collector::SpanContext::current_local_parent()?;
 
-    let span_id = span_context.span_id()?;
+    let span_id = span_context.span_id?;
 
     Some(OtelSpanContext::new(
-        OtelTraceId::from_bytes(span_context.trace_id().to_bytes()),
+        OtelTraceId::from_bytes(span_context.trace_id.to_bytes()),
         OtelSpanId::from_bytes(span_id.to_bytes()),
-        map_trace_flags(span_context.trace_flags()),
+        map_trace_flags(span_context.trace_flags),
         false,
-        map_trace_state(span_context.trace_state()),
+        map_trace_state(span_context.trace_state.as_header_value()),
     ))
 }
 
@@ -180,15 +180,15 @@ fn map_links(links: Vec<SpanContext>) -> SpanLinks {
         .into_iter()
         .map(|link| {
             let span_id = link
-                .span_id()
+                .span_id
                 .map(|span_id| OtelSpanId::from_bytes(span_id.to_bytes()))
                 .unwrap_or(OtelSpanId::INVALID);
             let span_context = OtelSpanContext::new(
-                OtelTraceId::from_bytes(link.trace_id().to_bytes()),
+                OtelTraceId::from_bytes(link.trace_id.to_bytes()),
                 span_id,
-                map_trace_flags(link.trace_flags()),
+                map_trace_flags(link.trace_flags),
                 false,
-                map_trace_state(link.trace_state()),
+                map_trace_state(link.trace_state.as_header_value()),
             );
             Link::with_context(span_context)
         })

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -178,16 +178,19 @@ fn map_trace_state(trace_state: Option<&str>) -> OtelTraceState {
 fn map_links(links: Vec<SpanContext>) -> SpanLinks {
     let links = links
         .into_iter()
-        .filter_map(|link| {
-            let span_id = link.span_id()?;
+        .map(|link| {
+            let span_id = link
+                .span_id()
+                .map(|span_id| OtelSpanId::from_bytes(span_id.to_bytes()))
+                .unwrap_or(OtelSpanId::INVALID);
             let span_context = OtelSpanContext::new(
                 OtelTraceId::from_bytes(link.trace_id().to_bytes()),
-                OtelSpanId::from_bytes(span_id.to_bytes()),
+                span_id,
                 map_trace_flags(link.trace_flags()),
                 false,
                 map_trace_state(link.trace_state()),
             );
-            Some(Link::with_context(span_context))
+            Link::with_context(span_context)
         })
         .collect();
 
@@ -406,6 +409,9 @@ mod tests {
         )
         .with_trace_flags(fastrace::collector::TraceFlags::SAMPLED)
         .with_trace_state("vendor=value");
+        let root_link = SpanContext::root(trace_id("abc"))
+            .with_trace_flags(fastrace::collector::TraceFlags::SAMPLED)
+            .with_trace_state("root=value");
 
         let spans = reporter.convert(vec![SpanRecord {
             trace_id: trace_id("0af7651916cd43dd8448eb211c80319c"),
@@ -418,7 +424,7 @@ mod tests {
             name: Cow::Borrowed("span"),
             properties: vec![],
             events: vec![],
-            links: vec![link],
+            links: vec![link, root_link],
         }]);
 
         assert_eq!(spans.len(), 1);
@@ -432,10 +438,19 @@ mod tests {
         assert_eq!(span.span_context.trace_flags().to_u8(), 0x03);
         assert_eq!(span.span_context.trace_state().header(), "vendor=value");
 
-        assert_eq!(span.links.links.len(), 1);
+        assert_eq!(span.links.links.len(), 2);
         let link = &span.links.links[0].span_context;
         assert_eq!(link.span_id().to_string(), "1111111111111111");
         assert!(link.is_sampled());
         assert_eq!(link.trace_state().header(), "vendor=value");
+
+        let root_link = &span.links.links[1].span_context;
+        assert_eq!(
+            root_link.trace_id().to_string(),
+            "00000000000000000000000000000abc"
+        );
+        assert_eq!(root_link.span_id(), OtelSpanId::INVALID);
+        assert!(root_link.is_sampled());
+        assert_eq!(root_link.trace_state().header(), "root=value");
     }
 }

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -35,10 +35,12 @@ use opentelemetry::KeyValue;
 use opentelemetry::trace::Event;
 use opentelemetry::trace::Link;
 use opentelemetry::trace::SpanContext as OtelSpanContext;
+use opentelemetry::trace::SpanId as OtelSpanId;
 use opentelemetry::trace::SpanKind;
 use opentelemetry::trace::Status;
-use opentelemetry::trace::TraceFlags;
-use opentelemetry::trace::TraceState;
+use opentelemetry::trace::TraceFlags as OtelTraceFlags;
+use opentelemetry::trace::TraceId as OtelTraceId;
+use opentelemetry::trace::TraceState as OtelTraceState;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::SpanData;
@@ -112,18 +114,14 @@ pub struct OpenTelemetryReporter {
 pub fn current_opentelemetry_context() -> Option<OtelSpanContext> {
     let span_context = fastrace::collector::SpanContext::current_local_parent()?;
 
-    let trace_flags = if span_context.sampled {
-        TraceFlags::SAMPLED
-    } else {
-        TraceFlags::default()
-    };
+    let span_id = span_context.span_id()?;
 
     Some(OtelSpanContext::new(
-        span_context.trace_id.0.into(),
-        span_context.span_id.0.into(),
-        trace_flags,
+        OtelTraceId::from_bytes(span_context.trace_id().to_bytes()),
+        OtelSpanId::from_bytes(span_id.to_bytes()),
+        map_trace_flags(span_context.trace_flags()),
         false,
-        TraceState::default(),
+        map_trace_state(span_context.trace_state()),
     ))
 }
 
@@ -167,23 +165,29 @@ fn map_events(events: Vec<EventRecord>) -> SpanEvents {
     queue
 }
 
+fn map_trace_flags(trace_flags: fastrace::collector::TraceFlags) -> OtelTraceFlags {
+    OtelTraceFlags::new(trace_flags.to_u8())
+}
+
+fn map_trace_state(trace_state: Option<&str>) -> OtelTraceState {
+    trace_state
+        .and_then(|header| header.parse().ok())
+        .unwrap_or_default()
+}
+
 fn map_links(links: Vec<SpanContext>) -> SpanLinks {
     let links = links
         .into_iter()
-        .map(|link| {
-            let trace_flags = if link.sampled {
-                TraceFlags::SAMPLED
-            } else {
-                TraceFlags::default()
-            };
+        .filter_map(|link| {
+            let span_id = link.span_id()?;
             let span_context = OtelSpanContext::new(
-                link.trace_id.0.into(),
-                link.span_id.0.into(),
-                trace_flags,
+                OtelTraceId::from_bytes(link.trace_id().to_bytes()),
+                OtelSpanId::from_bytes(span_id.to_bytes()),
+                map_trace_flags(link.trace_flags()),
                 false,
-                TraceState::default(),
+                map_trace_state(link.trace_state()),
             );
-            Link::with_context(span_context)
+            Some(Link::with_context(span_context))
         })
         .collect();
 
@@ -194,7 +198,7 @@ fn map_links(links: Vec<SpanContext>) -> SpanLinks {
 
 type ExportFuture<'a> = Pin<Box<dyn Future<Output = OTelSdkResult> + Send + 'a>>;
 
-fn default_block_on<'a>(future: ExportFuture<'a>) -> OTelSdkResult {
+fn default_block_on(future: ExportFuture<'_>) -> OTelSdkResult {
     pollster::block_on(future)
 }
 
@@ -237,9 +241,11 @@ impl OpenTelemetryReporter {
     ///     .with_block_on(move |future| handle.block_on(future));
     /// ```
     pub fn with_block_on<F>(mut self, block_on: F) -> Self
-    where F: for<'a> FnMut(Pin<Box<dyn Future<Output = OTelSdkResult> + Send + 'a>>) -> OTelSdkResult
+    where
+        F: for<'a> FnMut(Pin<Box<dyn Future<Output = OTelSdkResult> + Send + 'a>>) -> OTelSdkResult
             + Send
-            + 'static {
+            + 'static,
+    {
         self.block_on = Box::new(block_on);
         self
     }
@@ -252,6 +258,8 @@ impl OpenTelemetryReporter {
                      trace_id,
                      span_id,
                      parent_id,
+                     trace_flags,
+                     trace_state,
                      begin_time_unix_ns,
                      duration_ns,
                      name,
@@ -259,7 +267,9 @@ impl OpenTelemetryReporter {
                      events,
                      links,
                  }| {
-                    let parent_span_id = parent_id.0.into();
+                    let parent_span_id = parent_id.map_or(OtelSpanId::INVALID, |id| {
+                        OtelSpanId::from_bytes(id.to_bytes())
+                    });
                     let span_kind = span_kind(&properties);
                     let status = span_status(&properties);
                     let parent_span_is_remote = parent_span_is_remote(&properties);
@@ -274,11 +284,11 @@ impl OpenTelemetryReporter {
 
                     SpanData {
                         span_context: OtelSpanContext::new(
-                            trace_id.0.into(),
-                            span_id.0.into(),
-                            TraceFlags::default(),
+                            OtelTraceId::from_bytes(trace_id.to_bytes()),
+                            OtelSpanId::from_bytes(span_id.to_bytes()),
+                            map_trace_flags(trace_flags),
                             parent_span_is_remote,
-                            TraceState::default(),
+                            map_trace_state(trace_state.as_header_value()),
                         ),
                         parent_span_id,
                         parent_span_is_remote,
@@ -358,4 +368,74 @@ fn parent_span_is_remote(properties: &[(Cow<'static, str>, Cow<'static, str>)]) 
         .find(|(k, _)| k == SPAN_PARENT_SPAN_IS_REMOTE)
         .map(|(_, v)| v.to_lowercase().as_str() == "true")
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct NoopExporter;
+
+    impl SpanExporter for NoopExporter {
+        fn export(&self, _batch: Vec<SpanData>) -> impl Future<Output = OTelSdkResult> + Send {
+            std::future::ready(Ok(()))
+        }
+    }
+
+    fn trace_id(hex: &str) -> TraceId {
+        TraceId::from_hex(hex).unwrap()
+    }
+
+    fn span_id(hex: &str) -> SpanId {
+        SpanId::from_hex(hex).unwrap()
+    }
+
+    #[test]
+    fn convert_preserves_ids_flags_and_tracestate() {
+        let reporter = OpenTelemetryReporter::new(
+            NoopExporter,
+            Cow::Owned(Resource::builder_empty().build()),
+            InstrumentationScope::builder("test").build(),
+        );
+
+        let trace_state = fastrace::collector::TraceState::from_header_value("vendor=value");
+        let link = SpanContext::new(
+            trace_id("0af7651916cd43dd8448eb211c80319c"),
+            span_id("1111111111111111"),
+        )
+        .with_trace_flags(fastrace::collector::TraceFlags::SAMPLED)
+        .with_trace_state("vendor=value");
+
+        let spans = reporter.convert(vec![SpanRecord {
+            trace_id: trace_id("0af7651916cd43dd8448eb211c80319c"),
+            span_id: span_id("b7ad6b7169203331"),
+            parent_id: Some(span_id("2222222222222222")),
+            trace_flags: fastrace::collector::TraceFlags::new(0x03),
+            trace_state,
+            begin_time_unix_ns: 1,
+            duration_ns: 2,
+            name: Cow::Borrowed("span"),
+            properties: vec![],
+            events: vec![],
+            links: vec![link],
+        }]);
+
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        assert_eq!(
+            span.span_context.trace_id().to_string(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(span.span_context.span_id().to_string(), "b7ad6b7169203331");
+        assert_eq!(span.parent_span_id.to_string(), "2222222222222222");
+        assert_eq!(span.span_context.trace_flags().to_u8(), 0x03);
+        assert_eq!(span.span_context.trace_state().header(), "vendor=value");
+
+        assert_eq!(span.links.links.len(), 1);
+        let link = &span.links.links[0].span_context;
+        assert_eq!(link.span_id().to_string(), "1111111111111111");
+        assert!(link.is_sampled());
+        assert_eq!(link.trace_state().header(), "vendor=value");
+    }
 }

--- a/fastrace-opentelemetry/src/lib.rs
+++ b/fastrace-opentelemetry/src/lib.rs
@@ -409,9 +409,12 @@ mod tests {
         )
         .with_trace_flags(fastrace::collector::TraceFlags::SAMPLED)
         .with_trace_state("vendor=value");
-        let root_link = SpanContext::root(trace_id("abc"))
-            .with_trace_flags(fastrace::collector::TraceFlags::SAMPLED)
-            .with_trace_state("root=value");
+        let root_link = SpanContext {
+            trace_id: trace_id("abc"),
+            span_id: None,
+            trace_flags: fastrace::collector::TraceFlags::SAMPLED,
+            trace_state: fastrace::collector::TraceState::from_header_value("root=value"),
+        };
 
         let spans = reporter.convert(vec![SpanRecord {
             trace_id: trace_id("0af7651916cd43dd8448eb211c80319c"),

--- a/fastrace-opentelemetry/tests/context.rs
+++ b/fastrace-opentelemetry/tests/context.rs
@@ -70,6 +70,6 @@ fn otel_span_can_be_parented_by_fastrace_local_parent() {
     );
     assert_eq!(
         span.parent_span_id.to_string(),
-        root_context.span_id.to_string()
+        root_context.span_id.unwrap().to_string()
     );
 }

--- a/fastrace/Cargo.toml
+++ b/fastrace/Cargo.toml
@@ -41,6 +41,7 @@ opentelemetry_sdk = { workspace = true }
 pollster = { version = "0.4.0" }
 rand = "0.10.0"
 serial_test = "3.1"
+serde_json = "1.0"
 tokio = { workspace = true }
 tracing = { version = "0.1" }
 tracing-opentelemetry = { version = "0.32.0" }

--- a/fastrace/benches/compare.rs
+++ b/fastrace/benches/compare.rs
@@ -135,7 +135,15 @@ fn fastrace_harness(n: usize) {
         }
     }
 
-    let root = Span::root("parent", SpanContext::root(TraceId::from_hex("c").unwrap()));
+    let root = Span::root(
+        "parent",
+        SpanContext {
+            trace_id: TraceId::from_hex("c").unwrap(),
+            span_id: None,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+        },
+    );
     let _g = root.set_local_parent();
 
     dummy_fastrace(n);

--- a/fastrace/benches/compare.rs
+++ b/fastrace/benches/compare.rs
@@ -135,7 +135,7 @@ fn fastrace_harness(n: usize) {
         }
     }
 
-    let root = Span::root("parent", SpanContext::new(TraceId(12), SpanId::default()));
+    let root = Span::root("parent", SpanContext::root(TraceId::from_hex("c").unwrap()));
     let _g = root.set_local_parent();
 
     dummy_fastrace(n);

--- a/fastrace/benches/trace.rs
+++ b/fastrace/benches/trace.rs
@@ -7,6 +7,15 @@ fn main() {
     divan::main();
 }
 
+fn root_context() -> SpanContext {
+    SpanContext {
+        trace_id: TraceId::from_hex("c").unwrap(),
+        span_id: None,
+        trace_flags: TraceFlags::SAMPLED,
+        trace_state: TraceState::EMPTY,
+    }
+}
+
 #[divan::bench(args = [1, 10, 100, 1000, 10000])]
 fn concurrent(bencher: Bencher, len: usize) {
     init_fastrace();
@@ -17,8 +26,7 @@ fn concurrent(bencher: Bencher, len: usize) {
             .map(|_| {
                 std::thread::spawn(move || {
                     for _ in 0..len {
-                        let _ =
-                            Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
+                        let _ = Span::root("root", root_context());
                     }
                 })
             })
@@ -43,7 +51,7 @@ fn wide_raw(bencher: Bencher, len: usize) {
 fn wide(bencher: Bencher, len: usize) {
     init_fastrace();
     bencher.bench(|| {
-        let root = Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
+        let root = Span::root("root", root_context());
         let _sg = root.set_local_parent();
         dummy_iter(len - 1);
     });
@@ -62,7 +70,7 @@ fn deep_raw(bencher: Bencher, len: usize) {
 fn deep(bencher: Bencher, len: usize) {
     init_fastrace();
     bencher.bench(|| {
-        let root = Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
+        let root = Span::root("root", root_context());
         let _sg = root.set_local_parent();
         dummy_rec(len - 1);
     });
@@ -79,7 +87,7 @@ fn future(bencher: Bencher, len: u32) {
     }
 
     bencher.bench(|| {
-        let root = Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
+        let root = Span::root("root", root_context());
         pollster::block_on(f(len).in_span(root));
     });
 }

--- a/fastrace/benches/trace.rs
+++ b/fastrace/benches/trace.rs
@@ -18,7 +18,7 @@ fn concurrent(bencher: Bencher, len: usize) {
                 std::thread::spawn(move || {
                     for _ in 0..len {
                         let _ =
-                            Span::root("root", SpanContext::new(TraceId(12), SpanId::default()));
+                            Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
                     }
                 })
             })
@@ -43,7 +43,7 @@ fn wide_raw(bencher: Bencher, len: usize) {
 fn wide(bencher: Bencher, len: usize) {
     init_fastrace();
     bencher.bench(|| {
-        let root = Span::root("root", SpanContext::new(TraceId(12), SpanId::default()));
+        let root = Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
         let _sg = root.set_local_parent();
         dummy_iter(len - 1);
     });
@@ -62,7 +62,7 @@ fn deep_raw(bencher: Bencher, len: usize) {
 fn deep(bencher: Bencher, len: usize) {
     init_fastrace();
     bencher.bench(|| {
-        let root = Span::root("root", SpanContext::new(TraceId(12), SpanId::default()));
+        let root = Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
         let _sg = root.set_local_parent();
         dummy_rec(len - 1);
     });
@@ -79,7 +79,7 @@ fn future(bencher: Bencher, len: u32) {
     }
 
     bencher.bench(|| {
-        let root = Span::root("root", SpanContext::new(TraceId(12), SpanId::default()));
+        let root = Span::root("root", SpanContext::root(TraceId::from_hex("c").unwrap()));
         pollster::block_on(f(len).in_span(root));
     });
 }

--- a/fastrace/src/collector/global_collector.rs
+++ b/fastrace/src/collector/global_collector.rs
@@ -19,7 +19,9 @@ use crate::collector::SpanContext;
 use crate::collector::SpanId;
 use crate::collector::SpanRecord;
 use crate::collector::SpanSet;
+use crate::collector::TraceFlags;
 use crate::collector::TraceId;
+use crate::collector::TraceState;
 use crate::collector::command::CancelCollect;
 use crate::collector::command::CollectCommand;
 use crate::collector::command::DropCollect;
@@ -145,8 +147,15 @@ impl GlobalCollect {
 
 struct SpanCollection {
     spans: SpanSet,
+    context: TraceRecordContext,
+}
+
+#[derive(Clone)]
+struct TraceRecordContext {
     trace_id: TraceId,
-    parent_id: SpanId,
+    parent_id: Option<SpanId>,
+    trace_flags: TraceFlags,
+    trace_state: TraceState,
 }
 
 #[derive(Default)]
@@ -263,15 +272,23 @@ impl GlobalCollector {
                 if !active_collector.canceled {
                     active_collector.span_collections.push(SpanCollection {
                         spans,
-                        trace_id: collect_token.trace_id,
-                        parent_id: collect_token.parent_id,
+                        context: TraceRecordContext {
+                            trace_id: collect_token.trace_id,
+                            parent_id: collect_token.parent_id,
+                            trace_flags: collect_token.trace_flags,
+                            trace_state: collect_token.trace_state,
+                        },
                     });
                 }
             } else {
                 self.stale_spans.push(SpanCollection {
                     spans,
-                    trace_id: collect_token.trace_id,
-                    parent_id: collect_token.parent_id,
+                    context: TraceRecordContext {
+                        trace_id: collect_token.trace_id,
+                        parent_id: collect_token.parent_id,
+                        trace_flags: collect_token.trace_flags,
+                        trace_state: collect_token.trace_state,
+                    },
                 });
             }
         }
@@ -292,9 +309,12 @@ impl GlobalCollector {
             }
         }
 
-        self.stale_spans.sort_by_key(|spans| spans.trace_id);
+        self.stale_spans.sort_by_key(|spans| spans.context.trace_id);
 
-        for spans in self.stale_spans.chunk_by(|a, b| a.trace_id == b.trace_id) {
+        for spans in self
+            .stale_spans
+            .chunk_by(|a, b| a.context.trace_id == b.context.trace_id)
+        {
             postprocess_span_collection(
                 spans,
                 &anchor,
@@ -314,14 +334,13 @@ impl LocalSpansInner {
         let anchor: Anchor = Anchor::new();
         let mut danglings = HashMap::new();
         let mut records = Vec::new();
-        amend_local_span(
-            self,
-            parent.trace_id,
-            parent.span_id,
-            &mut records,
-            &mut danglings,
-            &anchor,
-        );
+        let context = TraceRecordContext {
+            trace_id: parent.trace_id,
+            parent_id: parent.span_id,
+            trace_flags: parent.trace_flags,
+            trace_state: parent.trace_state,
+        };
+        amend_local_span(self, &context, &mut records, &mut danglings, &anchor);
         mount_danglings(&mut records, &mut danglings);
         records
     }
@@ -345,24 +364,21 @@ fn postprocess_span_collection<'a>(
         match &span_collection.spans {
             SpanSet::Span(raw_span) => amend_span(
                 raw_span,
-                span_collection.trace_id,
-                span_collection.parent_id,
+                &span_collection.context,
                 committed_records,
                 danglings,
                 anchor,
             ),
             SpanSet::LocalSpansInner(local_spans) => amend_local_span(
                 local_spans,
-                span_collection.trace_id,
-                span_collection.parent_id,
+                &span_collection.context,
                 committed_records,
                 danglings,
                 anchor,
             ),
             SpanSet::SharedLocalSpans(local_spans) => amend_local_span(
                 local_spans,
-                span_collection.trace_id,
-                span_collection.parent_id,
+                &span_collection.context,
                 committed_records,
                 danglings,
                 anchor,
@@ -375,14 +391,13 @@ fn postprocess_span_collection<'a>(
 
 fn amend_local_span(
     local_spans: &LocalSpansInner,
-    trace_id: TraceId,
-    parent_id: SpanId,
+    context: &TraceRecordContext,
     spans: &mut Vec<SpanRecord>,
     dangling: &mut HashMap<SpanId, Vec<DanglingItem>>,
     anchor: &Anchor,
 ) {
     for span in local_spans.spans.iter() {
-        let parent_id = span.parent_id.unwrap_or(parent_id);
+        let parent_id = span.parent_id.or(context.parent_id);
         match span.raw_kind {
             RawKind::Span => {
                 let begin_time_unix_ns = span.begin_instant.as_unix_nanos(anchor);
@@ -392,9 +407,11 @@ fn amend_local_span(
                     span.end_instant.as_unix_nanos(anchor)
                 };
                 spans.push(SpanRecord {
-                    trace_id,
+                    trace_id: context.trace_id,
                     span_id: span.id,
                     parent_id,
+                    trace_flags: context.trace_flags,
+                    trace_state: context.trace_state.clone(),
                     begin_time_unix_ns,
                     duration_ns: end_time_unix_ns.saturating_sub(begin_time_unix_ns),
                     name: span.name.clone(),
@@ -410,22 +427,28 @@ fn amend_local_span(
                     timestamp_unix_ns: begin_time_unix_ns,
                     properties: span.properties.clone(),
                 };
-                dangling
-                    .entry(parent_id)
-                    .or_default()
-                    .push(DanglingItem::Event(event));
+                if let Some(parent_id) = parent_id {
+                    dangling
+                        .entry(parent_id)
+                        .or_default()
+                        .push(DanglingItem::Event(event));
+                }
             }
             RawKind::Properties => {
-                dangling
-                    .entry(parent_id)
-                    .or_default()
-                    .push(DanglingItem::Properties(span.properties.clone()));
+                if let Some(parent_id) = parent_id {
+                    dangling
+                        .entry(parent_id)
+                        .or_default()
+                        .push(DanglingItem::Properties(span.properties.clone()));
+                }
             }
             RawKind::Link => {
-                dangling
-                    .entry(parent_id)
-                    .or_default()
-                    .push(DanglingItem::Links(span.links.clone()));
+                if let Some(parent_id) = parent_id {
+                    dangling
+                        .entry(parent_id)
+                        .or_default()
+                        .push(DanglingItem::Links(span.links.clone()));
+                }
             }
         }
     }
@@ -433,8 +456,7 @@ fn amend_local_span(
 
 fn amend_span(
     span: &RawSpan,
-    trace_id: TraceId,
-    parent_id: SpanId,
+    context: &TraceRecordContext,
     spans: &mut Vec<SpanRecord>,
     dangling: &mut HashMap<SpanId, Vec<DanglingItem>>,
     anchor: &Anchor,
@@ -444,9 +466,11 @@ fn amend_span(
             let begin_time_unix_ns = span.begin_instant.as_unix_nanos(anchor);
             let end_time_unix_ns = span.end_instant.as_unix_nanos(anchor);
             spans.push(SpanRecord {
-                trace_id,
+                trace_id: context.trace_id,
                 span_id: span.id,
-                parent_id,
+                parent_id: context.parent_id,
+                trace_flags: context.trace_flags,
+                trace_state: context.trace_state.clone(),
                 begin_time_unix_ns,
                 duration_ns: end_time_unix_ns.saturating_sub(begin_time_unix_ns),
                 name: span.name.clone(),
@@ -462,22 +486,28 @@ fn amend_span(
                 timestamp_unix_ns: begin_time_unix_ns,
                 properties: span.properties.clone(),
             };
-            dangling
-                .entry(parent_id)
-                .or_default()
-                .push(DanglingItem::Event(event));
+            if let Some(parent_id) = context.parent_id {
+                dangling
+                    .entry(parent_id)
+                    .or_default()
+                    .push(DanglingItem::Event(event));
+            }
         }
         RawKind::Properties => {
-            dangling
-                .entry(parent_id)
-                .or_default()
-                .push(DanglingItem::Properties(span.properties.clone()));
+            if let Some(parent_id) = context.parent_id {
+                dangling
+                    .entry(parent_id)
+                    .or_default()
+                    .push(DanglingItem::Properties(span.properties.clone()));
+            }
         }
         RawKind::Link => {
-            dangling
-                .entry(parent_id)
-                .or_default()
-                .push(DanglingItem::Links(span.links.clone()));
+            if let Some(parent_id) = context.parent_id {
+                dangling
+                    .entry(parent_id)
+                    .or_default()
+                    .push(DanglingItem::Links(span.links.clone()));
+            }
         }
     }
 }

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 use std::fmt;
 use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use crate::Span;
 use crate::local::local_span_stack::LOCAL_SPAN_STACK;
@@ -12,12 +13,42 @@ thread_local! {
     static LOCAL_ID_GENERATOR: Cell<(u32, u32)> = Cell::new((rand::random(), 0))
 }
 
+/// Error returned when a trace id is malformed or all zeroes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InvalidTraceId;
+
+impl fmt::Display for InvalidTraceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid trace id")
+    }
+}
+
+impl std::error::Error for InvalidTraceId {}
+
+/// Error returned when a span id is malformed or all zeroes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InvalidSpanId;
+
+impl fmt::Display for InvalidSpanId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid span id")
+    }
+}
+
+impl std::error::Error for InvalidSpanId {}
+
+fn is_all_zero(bytes: &[u8]) -> bool {
+    bytes.iter().all(|byte| *byte == 0)
+}
+
 /// An identifier for a trace, which groups a set of related spans together.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct TraceId(pub u128);
+///
+/// A valid `TraceId` contains at least one non-zero byte.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TraceId(u128);
 
 impl TraceId {
-    /// Create a random `TraceId`.
+    /// Create a random non-zero `TraceId`.
     ///
     /// # Examples
     ///
@@ -27,7 +58,42 @@ impl TraceId {
     /// let trace_id = TraceId::random();
     /// ```
     pub fn random() -> Self {
-        TraceId(rand::random())
+        loop {
+            let value = rand::random();
+            if value != 0 {
+                return Self(value);
+            }
+        }
+    }
+
+    /// Creates a `TraceId` from bytes.
+    ///
+    /// Returns `None` if all bytes are zero.
+    pub fn from_bytes(bytes: [u8; 16]) -> Option<Self> {
+        let value = u128::from_be_bytes(bytes);
+        if value != 0 { Some(Self(value)) } else { None }
+    }
+
+    /// Creates a `TraceId` from a hexadecimal string.
+    ///
+    /// The input may contain fewer than 32 hexadecimal characters. Short inputs
+    /// are interpreted as if they were left-padded with zeroes. Returns an error
+    /// if the input is empty, longer than 32 hexadecimal characters, contains
+    /// non-hexadecimal characters, or represents all zeroes.
+    pub fn from_hex(hex: &str) -> Result<Self, InvalidTraceId> {
+        if hex.is_empty() || hex.len() > 32 {
+            return Err(InvalidTraceId);
+        }
+
+        match u128::from_str_radix(hex, 16) {
+            Ok(value) if value != 0 => Ok(Self(value)),
+            _ => Err(InvalidTraceId),
+        }
+    }
+
+    /// Returns this trace id as bytes.
+    pub const fn to_bytes(self) -> [u8; 16] {
+        self.0.to_be_bytes()
     }
 }
 
@@ -37,35 +103,41 @@ impl fmt::Display for TraceId {
     }
 }
 
+impl fmt::Debug for TraceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TraceId({self})")
+    }
+}
+
 impl FromStr for TraceId {
-    type Err = std::num::ParseIntError;
+    type Err = InvalidTraceId;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        u128::from_str_radix(s, 16).map(TraceId)
+        Self::from_hex(s)
     }
 }
 
 impl serde::Serialize for TraceId {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&format!("{:032x}", self.0))
+        serializer.serialize_str(&self.to_string())
     }
 }
 
 impl<'de> serde::Deserialize<'de> for TraceId {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        u128::from_str_radix(&s, 16)
-            .map(TraceId)
-            .map_err(serde::de::Error::custom)
+        TraceId::from_hex(&s).map_err(serde::de::Error::custom)
     }
 }
 
 /// An identifier for a span within a trace.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct SpanId(pub u64);
+///
+/// A valid `SpanId` is exactly 8 bytes and contains at least one non-zero byte.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SpanId([u8; 8]);
 
 impl SpanId {
-    /// Create a random `SpanId`.
+    /// Create a random non-zero `SpanId`.
     ///
     /// # Examples
     ///
@@ -75,12 +147,46 @@ impl SpanId {
     /// let span_id = SpanId::random();
     /// ```
     pub fn random() -> Self {
-        SpanId(rand::random())
+        loop {
+            let bytes = rand::random::<u64>().to_be_bytes();
+            if let Some(span_id) = Self::from_bytes(bytes) {
+                return span_id;
+            }
+        }
+    }
+
+    /// Creates a `SpanId` from bytes.
+    ///
+    /// Returns `None` if all bytes are zero.
+    pub fn from_bytes(bytes: [u8; 8]) -> Option<Self> {
+        (!is_all_zero(&bytes)).then_some(Self(bytes))
+    }
+
+    /// Creates a `SpanId` from a hexadecimal string.
+    ///
+    /// The input may contain fewer than 16 hexadecimal characters. Short inputs
+    /// are interpreted as if they were left-padded with zeroes. Returns an error
+    /// if the input is empty, longer than 16 hexadecimal characters, contains
+    /// non-hexadecimal characters, or represents all zeroes.
+    pub fn from_hex(hex: &str) -> Result<Self, InvalidSpanId> {
+        if hex.is_empty() || hex.len() > 16 {
+            return Err(InvalidSpanId);
+        }
+
+        match u64::from_str_radix(hex, 16) {
+            Ok(value) if value != 0 => Ok(Self(value.to_be_bytes())),
+            _ => Err(InvalidSpanId),
+        }
+    }
+
+    /// Returns this span id as bytes.
+    pub const fn to_bytes(self) -> [u8; 8] {
+        self.0
     }
 
     #[inline]
     #[doc(hidden)]
-    /// Create a non-zero `SpanId`
+    /// Create a non-zero `SpanId`.
     pub fn next_id() -> SpanId {
         LOCAL_ID_GENERATOR
             .try_with(|g| {
@@ -90,74 +196,175 @@ impl SpanId {
 
                 g.set((prefix, suffix));
 
-                SpanId(((prefix as u64) << 32) | (suffix as u64))
+                let raw = ((prefix as u64) << 32) | (suffix as u64);
+                SpanId::from_bytes(raw.to_be_bytes()).unwrap_or_else(SpanId::random)
             })
-            .unwrap_or_else(|_| SpanId(rand::random()))
+            .unwrap_or_else(|_| SpanId::random())
     }
 }
 
 impl fmt::Display for SpanId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:016x}", self.0)
+        write!(f, "{:016x}", u64::from_be_bytes(self.0))
     }
 }
 
 impl FromStr for SpanId {
-    type Err = std::num::ParseIntError;
+    type Err = InvalidSpanId;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        u64::from_str_radix(s, 16).map(SpanId)
+        Self::from_hex(s)
     }
 }
 
 impl serde::Serialize for SpanId {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&format!("{:016x}", self.0))
+        serializer.serialize_str(&self.to_string())
     }
 }
 
 impl<'de> serde::Deserialize<'de> for SpanId {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        u64::from_str_radix(&s, 16)
-            .map(SpanId)
-            .map_err(serde::de::Error::custom)
+        SpanId::from_hex(&s).map_err(serde::de::Error::custom)
     }
 }
 
-/// A struct representing the context of a span, including its [`TraceId`] and [`SpanId`].
-///
-/// [`TraceId`]: crate::collector::TraceId
-/// [`SpanId`]: crate::collector::SpanId
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct SpanContext {
-    pub trace_id: TraceId,
-    pub span_id: SpanId,
-    pub sampled: bool,
-}
+/// Flags carried by a W3C `traceparent` header.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TraceFlags(u8);
 
-impl SpanContext {
-    /// Creates a new `SpanContext` with the given [`TraceId`] and [`SpanId`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::prelude::*;
-    ///
-    /// let span_context = SpanContext::new(TraceId(12), SpanId::default());
-    /// ```
-    ///
-    /// [`TraceId`]: crate::collector::TraceId
-    /// [`SpanId`]: crate::collector::SpanId
-    pub fn new(trace_id: TraceId, span_id: SpanId) -> Self {
-        Self {
-            trace_id,
-            span_id,
-            sampled: true,
+impl TraceFlags {
+    /// Trace flags with no bits set.
+    pub const NOT_SAMPLED: TraceFlags = TraceFlags(0x00);
+
+    /// Trace flags with the W3C sampled bit set.
+    pub const SAMPLED: TraceFlags = TraceFlags(0x01);
+
+    /// Trace flags with the W3C random-trace-id bit set.
+    pub const RANDOM_TRACE_ID: TraceFlags = TraceFlags(0x02);
+
+    /// Constructs trace flags from raw W3C trace flag bits.
+    pub const fn new(flags: u8) -> Self {
+        TraceFlags(flags)
+    }
+
+    /// Returns the raw W3C trace flag bits.
+    pub const fn to_u8(self) -> u8 {
+        self.0
+    }
+
+    /// Returns `true` if the sampled bit is set.
+    pub fn is_sampled(self) -> bool {
+        self.0 & Self::SAMPLED.0 == Self::SAMPLED.0
+    }
+
+    /// Returns a copy of these flags with the sampled bit set or cleared.
+    pub fn with_sampled(self, sampled: bool) -> Self {
+        if sampled {
+            Self(self.0 | Self::SAMPLED.0)
+        } else {
+            Self(self.0 & !Self::SAMPLED.0)
         }
     }
 
-    /// Create a new `SpanContext` with a random trace id.
+    /// Returns `true` if the random-trace-id bit is set.
+    pub fn is_random_trace_id(self) -> bool {
+        self.0 & Self::RANDOM_TRACE_ID.0 == Self::RANDOM_TRACE_ID.0
+    }
+
+    /// Returns a copy of these flags with the random-trace-id bit set or cleared.
+    pub fn with_random_trace_id(self, random_trace_id: bool) -> Self {
+        if random_trace_id {
+            Self(self.0 | Self::RANDOM_TRACE_ID.0)
+        } else {
+            Self(self.0 & !Self::RANDOM_TRACE_ID.0)
+        }
+    }
+}
+
+impl fmt::LowerHex for TraceFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+/// A cheap pass-through representation of a W3C `tracestate` header.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TraceState(Option<Arc<str>>);
+
+impl TraceState {
+    /// An empty tracestate.
+    pub const EMPTY: TraceState = TraceState(None);
+
+    /// Creates an empty tracestate.
+    pub const fn empty() -> Self {
+        Self::EMPTY
+    }
+
+    /// Creates a tracestate from a header value.
+    ///
+    /// Empty strings are normalized to `None`.
+    pub fn from_header_value(header: impl Into<Arc<str>>) -> Self {
+        let header = header.into();
+        if header.is_empty() {
+            Self::EMPTY
+        } else {
+            Self(Some(header))
+        }
+    }
+
+    /// Returns the header value if this tracestate is present.
+    pub fn as_header_value(&self) -> Option<&str> {
+        self.0.as_deref()
+    }
+
+    /// Returns `true` when no tracestate is present.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+/// A cheap parent/link context for span creation and reporting.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SpanContext {
+    pub trace_id: TraceId,
+    pub span_id: Option<SpanId>,
+    pub trace_flags: TraceFlags,
+    pub trace_state: TraceState,
+}
+
+impl SpanContext {
+    /// W3C `traceparent` header name.
+    pub const TRACEPARENT_HEADER_NAME: &'static str = "traceparent";
+
+    /// W3C `tracestate` header name.
+    pub const TRACESTATE_HEADER_NAME: &'static str = "tracestate";
+
+    /// Creates a `SpanContext` from a trace id and a valid parent span id.
+    ///
+    /// Use [`SpanContext::root`] or [`SpanContext::random`] when starting a
+    /// trace without a remote parent.
+    pub fn new(trace_id: TraceId, span_id: SpanId) -> Self {
+        Self {
+            trace_id,
+            span_id: Some(span_id),
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+        }
+    }
+
+    /// Creates a root `SpanContext` with no remote parent span.
+    pub fn root(trace_id: TraceId) -> Self {
+        Self {
+            trace_id,
+            span_id: None,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+        }
+    }
+
+    /// Create a new root `SpanContext` with a random trace id and no remote parent.
     ///
     /// # Examples
     ///
@@ -167,30 +374,93 @@ impl SpanContext {
     /// let root = Span::root("root", SpanContext::random());
     /// ```
     pub fn random() -> Self {
-        Self {
-            trace_id: TraceId::random(),
-            span_id: SpanId(0),
-            sampled: true,
-        }
+        Self::root(TraceId::random())
+            .with_trace_flags(TraceFlags::SAMPLED.with_random_trace_id(true))
     }
 
-    /// Sets the `sampled` flag of the `SpanContext`.
+    /// Returns the trace id.
+    pub fn trace_id(&self) -> TraceId {
+        self.trace_id
+    }
+
+    /// Returns the parent or linked span id, if present.
+    pub fn span_id(&self) -> Option<SpanId> {
+        self.span_id
+    }
+
+    /// Returns the trace flags.
+    pub fn trace_flags(&self) -> TraceFlags {
+        self.trace_flags
+    }
+
+    /// Returns the tracestate header value, if present.
+    pub fn trace_state(&self) -> Option<&str> {
+        self.trace_state.as_header_value()
+    }
+
+    /// Returns `true` when the sampled trace flag is set.
+    pub fn is_sampled(&self) -> bool {
+        self.trace_flags.is_sampled()
+    }
+
+    /// Sets the sampled flag of the `SpanContext`.
     ///
-    /// When the `sampled` flag is `false`, the spans will not be collected, but the parent-child
+    /// When the sampled flag is `false`, the spans will not be collected, but the parent-child
     /// relationship will still be maintained and the `SpanContext` can still be propagated.
-    ///
-    /// The default value is `true`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::prelude::*;
-    ///
-    /// let span_context = SpanContext::new(TraceId(12), SpanId(34)).sampled(false);
-    /// ```
     pub fn sampled(mut self, sampled: bool) -> Self {
-        self.sampled = sampled;
+        self.trace_flags = self.trace_flags.with_sampled(sampled);
         self
+    }
+
+    /// Sets the trace flags of the `SpanContext`.
+    pub fn with_trace_flags(mut self, trace_flags: TraceFlags) -> Self {
+        self.trace_flags = trace_flags;
+        self
+    }
+
+    /// Sets the tracestate of the `SpanContext`.
+    ///
+    /// Empty strings are normalized to no tracestate.
+    pub fn with_trace_state(mut self, trace_state: impl Into<Arc<str>>) -> Self {
+        self.trace_state = TraceState::from_header_value(trace_state);
+        self
+    }
+
+    /// Encodes this span context into a W3C `traceparent` header value.
+    ///
+    /// Returns `None` if this context represents a root with no remote parent span id.
+    pub fn encode_traceparent(&self) -> Option<String> {
+        let span_id = self.span_id?;
+        Some(format!(
+            "00-{}-{}-{:02x}",
+            self.trace_id, span_id, self.trace_flags
+        ))
+    }
+
+    /// Decodes a span context from a W3C `traceparent` header value.
+    pub fn decode_traceparent(traceparent: &str) -> Option<Self> {
+        let mut parts = traceparent.split('-');
+
+        match (
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+        ) {
+            (Some("00"), Some(trace_id), Some(span_id), Some(trace_flags), None) => {
+                if trace_id.len() != 32 || span_id.len() != 16 || trace_flags.len() != 2 {
+                    return None;
+                }
+                Some(Self {
+                    trace_id: TraceId::from_hex(trace_id).ok()?,
+                    span_id: Some(SpanId::from_hex(span_id).ok()?),
+                    trace_flags: TraceFlags::new(u8::from_str_radix(trace_flags, 16).ok()?),
+                    trace_state: TraceState::EMPTY,
+                })
+            }
+            _ => None,
+        }
     }
 
     /// Creates a `SpanContext` from the given [`Span`]. If the `Span` is a noop span,
@@ -220,7 +490,8 @@ impl SpanContext {
             Some(Self {
                 trace_id: collect_token.trace_id,
                 span_id: collect_token.parent_id,
-                sampled: collect_token.is_sampled,
+                trace_flags: collect_token.trace_flags,
+                trace_state: collect_token.trace_state,
             })
         }
     }
@@ -254,339 +525,27 @@ impl SpanContext {
             Some(Self {
                 trace_id: collect_token.trace_id,
                 span_id: collect_token.parent_id,
-                sampled: collect_token.is_sampled,
+                trace_flags: collect_token.trace_flags,
+                trace_state: collect_token.trace_state,
             })
         }
-    }
-
-    /// Decodes the `SpanContext` from a [W3C Trace Context](https://www.w3.org/TR/trace-context/)
-    /// `traceparent` header string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::prelude::*;
-    ///
-    /// let span_context = SpanContext::decode_w3c_traceparent(
-    ///     "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-    /// )
-    /// .unwrap();
-    ///
-    /// assert_eq!(
-    ///     span_context.trace_id,
-    ///     TraceId(0x0af7651916cd43dd8448eb211c80319c)
-    /// );
-    /// assert_eq!(span_context.span_id, SpanId(0xb7ad6b7169203331));
-    /// ```
-    pub fn decode_w3c_traceparent(traceparent: &str) -> Option<Self> {
-        let mut parts = traceparent.split('-');
-
-        match (
-            parts.next(),
-            parts.next(),
-            parts.next(),
-            parts.next(),
-            parts.next(),
-        ) {
-            (Some("00"), Some(trace_id), Some(span_id), Some(sampled), None) => {
-                let trace_id = u128::from_str_radix(trace_id, 16).ok()?;
-                let span_id = u64::from_str_radix(span_id, 16).ok()?;
-                let sampled = u8::from_str_radix(sampled, 16).ok()? & 1 == 1;
-                if trace_id == 0 || span_id == 0 {
-                    return None;
-                }
-                Some(Self::new(TraceId(trace_id), SpanId(span_id)).sampled(sampled))
-            }
-            _ => None,
-        }
-    }
-
-    /// Encodes the `SpanContext` into a [W3C Trace Context](https://www.w3.org/TR/trace-context/)
-    /// `traceparent` header string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::prelude::*;
-    ///
-    /// let span_context = SpanContext::new(TraceId(12), SpanId(34));
-    /// let traceparent = span_context.encode_w3c_traceparent();
-    ///
-    /// assert_eq!(
-    ///     traceparent,
-    ///     "00-0000000000000000000000000000000c-0000000000000022-01"
-    /// );
-    /// ```
-    pub fn encode_w3c_traceparent(&self) -> String {
-        format!(
-            "00-{:032x}-{:016x}-{:02x}",
-            self.trace_id.0, self.span_id.0, self.sampled as u8,
-        )
-    }
-
-    /// Encodes the `SpanContext` as a [W3C Trace Context](https://www.w3.org/TR/trace-context/)
-    /// `traceparent` header string with a sampled flag.
-    #[deprecated(since = "0.7.0", note = "Please use `SpanContext::sampled()` instead")]
-    pub fn encode_w3c_traceparent_with_sampled(&self, sampled: bool) -> String {
-        self.sampled(sampled).encode_w3c_traceparent()
-    }
-}
-
-impl Default for SpanContext {
-    fn default() -> Self {
-        Self::random()
     }
 }
 
 impl serde::Serialize for SpanContext {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.encode_w3c_traceparent().serialize(serializer)
+        let traceparent = self.encode_traceparent().ok_or_else(|| {
+            serde::ser::Error::custom("span context has no span id for traceparent")
+        })?;
+        traceparent.serialize(serializer)
     }
 }
 
 impl<'de> serde::Deserialize<'de> for SpanContext {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        SpanContext::decode_w3c_traceparent(&s)
+        SpanContext::decode_traceparent(&s)
             .ok_or_else(|| serde::de::Error::custom("invalid w3c traceparent"))
-    }
-}
-
-/// A complete [W3C Trace Context](https://www.w3.org/TR/trace-context/) representation
-/// carrying both the `traceparent` and `tracestate` headers.
-///
-/// [`SpanContext`] is `Copy` and only stores trace-id, span-id, and the sampled flag
-/// (the `traceparent` portion). `W3CTraceContext` extends it with an optional
-/// `tracestate` string so that vendor-specific key-value pairs survive propagation
-/// across process boundaries.
-///
-/// **Important:** `W3CTraceContext` is a **boundary/header wrapper** for encoding and
-/// decoding W3C headers at RPC injection/extraction points. The `tracestate` field is
-/// **not** carried through fastrace's internal span machinery — converting to a
-/// [`SpanContext`] (e.g. via [`Span::root`] or field access) discards the tracestate.
-/// **If you extract the `span_context`, create spans, and later need to inject outgoing
-/// headers via `SpanContext::from_span` or `SpanContext::current_local_parent()`, the
-/// original `tracestate` will be lost.** Store the `W3CTraceContext` or `tracestate`
-/// value separately if you need to preserve it for outbound propagation.
-///
-/// # Examples
-///
-/// ```
-/// use fastrace::collector::W3CTraceContext;
-/// use fastrace::prelude::*;
-///
-/// // Decode from incoming HTTP headers.
-/// let ctx = W3CTraceContext::decode(
-///     "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-///     Some("rw=frontend,congo=t61rcWkgMzE"),
-/// )
-/// .unwrap();
-///
-/// assert_eq!(
-///     ctx.span_context.trace_id,
-///     TraceId(0x0af7651916cd43dd8448eb211c80319c)
-/// );
-/// assert_eq!(ctx.tracestate(), Some("rw=frontend,congo=t61rcWkgMzE"));
-///
-/// // Encode for outgoing HTTP headers.
-/// let traceparent = ctx.encode_traceparent();
-/// let tracestate = ctx.encode_tracestate();
-/// assert_eq!(
-///     traceparent,
-///     "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-/// );
-/// assert_eq!(tracestate, Some("rw=frontend,congo=t61rcWkgMzE"));
-///
-/// // Start a root span (note: tracestate is not retained in the span).
-/// let root = Span::root("server", ctx.span_context);
-/// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct W3CTraceContext {
-    /// The core span context (trace-id, span-id, sampled flag).
-    pub span_context: SpanContext,
-    tracestate: Option<String>,
-}
-
-impl W3CTraceContext {
-    /// Creates a new `W3CTraceContext` from a [`SpanContext`] with no `tracestate`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::collector::W3CTraceContext;
-    /// use fastrace::prelude::*;
-    ///
-    /// let ctx = W3CTraceContext::new(SpanContext::new(TraceId(12), SpanId(34)));
-    /// assert_eq!(ctx.tracestate(), None);
-    /// ```
-    pub fn new(span_context: SpanContext) -> Self {
-        Self {
-            span_context,
-            tracestate: None,
-        }
-    }
-
-    /// Attaches a `tracestate` string. Replaces any existing value.
-    ///
-    /// An empty string is normalized to `None` (no tracestate), consistent
-    /// with [`W3CTraceContext::decode`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::collector::W3CTraceContext;
-    /// use fastrace::prelude::*;
-    ///
-    /// let ctx = W3CTraceContext::new(SpanContext::random()).with_tracestate("rw=frontend");
-    /// assert_eq!(ctx.tracestate(), Some("rw=frontend"));
-    ///
-    /// // Empty string is normalized to None.
-    /// let ctx = ctx.with_tracestate("");
-    /// assert_eq!(ctx.tracestate(), None);
-    /// ```
-    pub fn with_tracestate(mut self, tracestate: impl Into<String>) -> Self {
-        let ts = tracestate.into();
-        self.tracestate = if ts.is_empty() { None } else { Some(ts) };
-        self
-    }
-
-    /// Returns the `tracestate` value, if any.
-    pub fn tracestate(&self) -> Option<&str> {
-        self.tracestate.as_deref()
-    }
-
-    /// Encodes the `traceparent` header value.
-    ///
-    /// This delegates to [`SpanContext::encode_w3c_traceparent`].
-    pub fn encode_traceparent(&self) -> String {
-        self.span_context.encode_w3c_traceparent()
-    }
-
-    /// Returns the `tracestate` header value, if present.
-    ///
-    /// Returns `None` when no tracestate was set, meaning the header should be
-    /// omitted from the outgoing request.
-    pub fn encode_tracestate(&self) -> Option<&str> {
-        self.tracestate.as_deref()
-    }
-
-    /// Decodes a `W3CTraceContext` from `traceparent` and optional `tracestate`
-    /// header values.
-    ///
-    /// Returns `None` if the `traceparent` string is malformed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::collector::W3CTraceContext;
-    /// use fastrace::prelude::*;
-    ///
-    /// let ctx = W3CTraceContext::decode(
-    ///     "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-    ///     Some("rw=frontend"),
-    /// )
-    /// .unwrap();
-    ///
-    /// assert_eq!(ctx.tracestate(), Some("rw=frontend"));
-    ///
-    /// // Without tracestate.
-    /// let ctx2 = W3CTraceContext::decode(
-    ///     "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-    ///     None,
-    /// )
-    /// .unwrap();
-    /// assert_eq!(ctx2.tracestate(), None);
-    /// ```
-    pub fn decode(traceparent: &str, tracestate: Option<&str>) -> Option<Self> {
-        let span_context = SpanContext::decode_w3c_traceparent(traceparent)?;
-        Some(Self {
-            span_context,
-            tracestate: tracestate.filter(|s| !s.is_empty()).map(|s| s.to_string()),
-        })
-    }
-
-    /// Encodes both `traceparent` and `tracestate` into a list of header
-    /// key-value pairs suitable for HTTP propagation.
-    ///
-    /// The returned vector always contains the `traceparent` entry. The
-    /// `tracestate` entry is included only when a tracestate value is present.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::collector::W3CTraceContext;
-    /// use fastrace::prelude::*;
-    ///
-    /// let ctx = W3CTraceContext::new(SpanContext::new(TraceId(1), SpanId(2)))
-    ///     .with_tracestate("rw=frontend");
-    /// let headers = ctx.encode_headers();
-    /// assert_eq!(headers.len(), 2);
-    /// assert_eq!(headers[0].0, "traceparent");
-    /// assert_eq!(headers[1].0, "tracestate");
-    /// assert_eq!(headers[1].1, "rw=frontend");
-    /// ```
-    pub fn encode_headers(&self) -> Vec<(String, String)> {
-        let mut headers = vec![("traceparent".to_string(), self.encode_traceparent())];
-        if let Some(ts) = &self.tracestate {
-            headers.push(("tracestate".to_string(), ts.clone()));
-        }
-        headers
-    }
-
-    /// Decodes a `W3CTraceContext` from an iterator of header key-value pairs.
-    ///
-    /// The lookup is case-insensitive for the header names, per the W3C spec.
-    /// **If multiple `tracestate` headers are present, they are joined with commas
-    /// in the order encountered, per [W3C Trace Context §3.3.1.1](https://www.w3.org/TR/trace-context/#tracestate-header).**
-    /// Empty or whitespace-only `tracestate` values are ignored.
-    /// Returns `None` if no valid `traceparent` header is found.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use fastrace::collector::W3CTraceContext;
-    ///
-    /// let headers = vec![
-    ///     (
-    ///         "traceparent",
-    ///         "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-    ///     ),
-    ///     ("tracestate", "rw=frontend,congo=t61rcWkgMzE"),
-    /// ];
-    ///
-    /// let ctx = W3CTraceContext::decode_headers(headers).unwrap();
-    /// assert_eq!(ctx.tracestate(), Some("rw=frontend,congo=t61rcWkgMzE"));
-    /// ```
-    pub fn decode_headers<'a>(
-        headers: impl IntoIterator<Item = (&'a str, &'a str)>,
-    ) -> Option<Self> {
-        let mut traceparent = None;
-        let mut tracestate_parts: Vec<&str> = Vec::new();
-
-        for (key, value) in headers {
-            if key.eq_ignore_ascii_case("traceparent") {
-                traceparent = Some(value);
-            } else if key.eq_ignore_ascii_case("tracestate") {
-                let trimmed = value.trim();
-                if !trimmed.is_empty() {
-                    tracestate_parts.push(trimmed);
-                }
-            }
-        }
-
-        let tracestate = if tracestate_parts.is_empty() {
-            None
-        } else {
-            Some(tracestate_parts.join(","))
-        };
-
-        Self::decode(traceparent?, tracestate.as_deref())
-    }
-}
-
-impl From<SpanContext> for W3CTraceContext {
-    fn from(span_context: SpanContext) -> Self {
-        Self::new(span_context)
     }
 }
 
@@ -595,6 +554,14 @@ mod tests {
     use std::collections::HashSet;
 
     use super::*;
+
+    fn trace_id(value: u128) -> TraceId {
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+    }
+
+    fn span_id(value: u64) -> SpanId {
+        SpanId::from_bytes(value.to_be_bytes()).unwrap()
+    }
 
     #[test]
     #[allow(clippy::needless_collect)]
@@ -618,228 +585,174 @@ mod tests {
     }
 
     #[test]
-    fn w3c_trace_context_decode_with_tracestate() {
-        let ctx = W3CTraceContext::decode(
-            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            Some("rw=frontend,congo=t61rcWkgMzE"),
-        )
-        .unwrap();
-
-        assert_eq!(
-            ctx.span_context.trace_id,
-            TraceId(0x0af7651916cd43dd8448eb211c80319c)
+    fn zero_ids_are_rejected() {
+        assert!(TraceId::from_bytes([0; 16]).is_none());
+        assert!(SpanId::from_bytes([0; 8]).is_none());
+        assert!(TraceId::from_hex("").is_err());
+        assert!(SpanId::from_hex("").is_err());
+        assert!(TraceId::from_hex("0").is_err());
+        assert!(SpanId::from_hex("0").is_err());
+        assert!(TraceId::from_hex("00000000000000000000000000000000").is_err());
+        assert!(SpanId::from_hex("0000000000000000").is_err());
+        assert!(
+            "00000000000000000000000000000000"
+                .parse::<TraceId>()
+                .is_err()
         );
-        assert_eq!(ctx.span_context.span_id, SpanId(0xb7ad6b7169203331));
-        assert!(ctx.span_context.sampled);
-        assert_eq!(ctx.tracestate(), Some("rw=frontend,congo=t61rcWkgMzE"));
+        assert!("0000000000000000".parse::<SpanId>().is_err());
     }
 
     #[test]
-    fn w3c_trace_context_decode_without_tracestate() {
-        let ctx = W3CTraceContext::decode(
+    fn short_hex_ids_are_left_padded() {
+        let trace = TraceId::from_hex("abc").unwrap();
+        assert_eq!(trace.to_string(), "00000000000000000000000000000abc");
+        assert_eq!(TraceId::from_bytes(0x0abcu128.to_be_bytes()), Some(trace));
+
+        let span = SpanId::from_hex("abc").unwrap();
+        assert_eq!(span.to_string(), "0000000000000abc");
+        assert_eq!(SpanId::from_bytes(0x0abcu64.to_be_bytes()), Some(span));
+
+        assert!(TraceId::from_hex("000000000000000000000000000000001").is_err());
+        assert!(SpanId::from_hex("00000000000000001").is_err());
+    }
+
+    #[test]
+    fn valid_ids_roundtrip() {
+        let trace = TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap();
+        assert_eq!(trace.to_string(), "0af7651916cd43dd8448eb211c80319c");
+        assert_eq!(TraceId::from_bytes(trace.to_bytes()), Some(trace));
+        assert_eq!(
+            TraceId::from_bytes(0x0af7651916cd43dd8448eb211c80319cu128.to_be_bytes()),
+            Some(trace)
+        );
+
+        let span = SpanId::from_hex("b7ad6b7169203331").unwrap();
+        assert_eq!(span.to_string(), "b7ad6b7169203331");
+        assert_eq!(SpanId::from_bytes(span.to_bytes()), Some(span));
+        assert_eq!(
+            SpanId::from_bytes(0xb7ad6b7169203331u64.to_be_bytes()),
+            Some(span)
+        );
+    }
+
+    #[test]
+    fn span_context_decode_traceparent() {
+        let ctx = SpanContext::decode_traceparent(
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            None,
+        )
+        .unwrap()
+        .with_trace_state("rw=frontend,congo=t61rcWkgMzE");
+
+        assert_eq!(ctx.trace_id, trace_id(0x0af7651916cd43dd8448eb211c80319c));
+        assert_eq!(ctx.span_id, Some(span_id(0xb7ad6b7169203331)));
+        assert!(ctx.is_sampled());
+        assert_eq!(ctx.trace_state(), Some("rw=frontend,congo=t61rcWkgMzE"));
+    }
+
+    #[test]
+    fn span_context_decode_without_tracestate() {
+        let ctx = SpanContext::decode_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
         )
         .unwrap();
 
-        assert_eq!(ctx.tracestate(), None);
+        assert_eq!(ctx.trace_state(), None);
     }
 
     #[test]
-    fn w3c_trace_context_decode_empty_tracestate() {
-        let ctx = W3CTraceContext::decode(
-            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            Some(""),
+    fn span_context_empty_tracestate() {
+        let ctx = SpanContext::new(trace_id(1), span_id(2)).with_trace_state("");
+
+        assert_eq!(ctx.trace_state(), None);
+    }
+
+    #[test]
+    fn span_context_decode_invalid_traceparent() {
+        assert!(SpanContext::decode_traceparent("invalid").is_none());
+        assert!(SpanContext::decode_traceparent("00-abc-b7ad6b7169203331-01").is_none());
+        assert!(
+            SpanContext::decode_traceparent("00-0af7651916cd43dd8448eb211c80319c-abc-01").is_none()
+        );
+        assert!(
+            SpanContext::decode_traceparent(
+                "00-00000000000000000000000000000000-b7ad6b7169203331-01",
+            )
+            .is_none()
+        );
+        assert!(
+            SpanContext::decode_traceparent(
+                "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn span_context_encode_roundtrip() {
+        let original = SpanContext::decode_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03",
         )
-        .unwrap();
+        .unwrap()
+        .with_trace_state("rw=frontend");
 
-        assert_eq!(ctx.tracestate(), None);
-    }
+        assert!(original.trace_flags().is_sampled());
+        assert!(original.trace_flags().is_random_trace_id());
 
-    #[test]
-    fn w3c_trace_context_decode_invalid_traceparent() {
-        assert!(W3CTraceContext::decode("invalid", Some("rw=frontend")).is_none());
-    }
-
-    #[test]
-    fn w3c_trace_context_encode_roundtrip() {
-        let original = W3CTraceContext::decode(
-            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            Some("rw=frontend"),
-        )
-        .unwrap();
-
-        let traceparent = original.encode_traceparent();
-        let tracestate = original.encode_tracestate();
-
-        let decoded = W3CTraceContext::decode(&traceparent, tracestate).unwrap();
+        let traceparent = original.encode_traceparent().unwrap();
+        let decoded = SpanContext::decode_traceparent(&traceparent)
+            .unwrap()
+            .with_trace_state(original.trace_state().unwrap());
 
         assert_eq!(original, decoded);
     }
 
     #[test]
-    fn w3c_trace_context_encode_roundtrip_no_tracestate() {
-        let original = W3CTraceContext::decode(
+    fn trace_flags_sampled_roundtrip() {
+        let sampled = SpanContext::decode_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        )
+        .unwrap();
+        assert!(sampled.trace_flags().is_sampled());
+        assert_eq!(
+            sampled.encode_traceparent().unwrap(),
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        );
+
+        let not_sampled = SpanContext::decode_traceparent(
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00",
-            None,
         )
         .unwrap();
-
-        let traceparent = original.encode_traceparent();
-        let tracestate = original.encode_tracestate();
-
-        let decoded = W3CTraceContext::decode(&traceparent, tracestate).unwrap();
-
-        assert_eq!(original, decoded);
-        assert!(!decoded.span_context.sampled);
-    }
-
-    #[test]
-    fn w3c_trace_context_with_tracestate() {
-        let ctx = W3CTraceContext::new(SpanContext::new(TraceId(1), SpanId(2)));
-        assert_eq!(ctx.tracestate(), None);
-
-        let ctx = ctx.with_tracestate("rw=frontend");
-        assert_eq!(ctx.tracestate(), Some("rw=frontend"));
-
-        // Replace existing.
-        let ctx = ctx.with_tracestate("rw=backend");
-        assert_eq!(ctx.tracestate(), Some("rw=backend"));
-
-        // Empty string normalizes to None.
-        let ctx = ctx.with_tracestate("");
-        assert_eq!(ctx.tracestate(), None);
-    }
-
-    #[test]
-    fn w3c_trace_context_encode_headers() {
-        let ctx = W3CTraceContext::new(SpanContext::new(TraceId(1), SpanId(2)))
-            .with_tracestate("rw=frontend");
-
-        let headers = ctx.encode_headers();
-        assert_eq!(headers.len(), 2);
-        assert_eq!(headers[0].0, "traceparent");
+        assert!(!not_sampled.trace_flags().is_sampled());
         assert_eq!(
-            headers[0].1,
-            "00-00000000000000000000000000000001-0000000000000002-01"
+            not_sampled.encode_traceparent().unwrap(),
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
         );
-        assert_eq!(headers[1].0, "tracestate");
-        assert_eq!(headers[1].1, "rw=frontend");
     }
 
     #[test]
-    fn w3c_trace_context_encode_headers_no_tracestate() {
-        let ctx = W3CTraceContext::new(SpanContext::new(TraceId(1), SpanId(2)));
-        let headers = ctx.encode_headers();
-        assert_eq!(headers.len(), 1);
-        assert_eq!(headers[0].0, "traceparent");
+    fn span_context_with_tracestate() {
+        let ctx = SpanContext::new(trace_id(1), span_id(2));
+        assert_eq!(ctx.trace_state(), None);
+
+        let ctx = ctx.with_trace_state("rw=frontend");
+        assert_eq!(ctx.trace_state(), Some("rw=frontend"));
+
+        let ctx = ctx.with_trace_state("rw=backend");
+        assert_eq!(ctx.trace_state(), Some("rw=backend"));
+
+        let ctx = ctx.with_trace_state("");
+        assert_eq!(ctx.trace_state(), None);
     }
 
     #[test]
-    fn w3c_trace_context_decode_headers() {
-        let headers = vec![
-            (
-                "traceparent",
-                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            ),
-            ("tracestate", "rw=frontend,congo=t61rcWkgMzE"),
-        ];
-
-        let ctx = W3CTraceContext::decode_headers(headers).unwrap();
-        assert_eq!(
-            ctx.span_context.trace_id,
-            TraceId(0x0af7651916cd43dd8448eb211c80319c)
-        );
-        assert_eq!(ctx.tracestate(), Some("rw=frontend,congo=t61rcWkgMzE"));
+    fn span_context_header_name_constants() {
+        assert_eq!(SpanContext::TRACEPARENT_HEADER_NAME, "traceparent");
+        assert_eq!(SpanContext::TRACESTATE_HEADER_NAME, "tracestate");
     }
 
     #[test]
-    fn w3c_trace_context_decode_headers_case_insensitive() {
-        let headers = vec![
-            (
-                "Traceparent",
-                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            ),
-            ("TraceState", "rw=frontend"),
-        ];
-
-        let ctx = W3CTraceContext::decode_headers(headers).unwrap();
-        assert_eq!(ctx.tracestate(), Some("rw=frontend"));
-    }
-
-    #[test]
-    fn w3c_trace_context_decode_headers_no_traceparent() {
-        let headers = vec![("tracestate", "rw=frontend")];
-        assert!(W3CTraceContext::decode_headers(headers).is_none());
-    }
-
-    #[test]
-    fn w3c_trace_context_decode_headers_repeated_tracestate() {
-        // Per W3C spec, multiple tracestate headers should be joined with commas.
-        let headers = vec![
-            (
-                "traceparent",
-                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            ),
-            ("tracestate", "rw=frontend"),
-            ("tracestate", "congo=t61rcWkgMzE"),
-        ];
-
-        let ctx = W3CTraceContext::decode_headers(headers).unwrap();
-        assert_eq!(ctx.tracestate(), Some("rw=frontend,congo=t61rcWkgMzE"));
-    }
-
-    #[test]
-    fn w3c_trace_context_decode_headers_repeated_empty_mixed() {
-        let headers = vec![
-            (
-                "traceparent",
-                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            ),
-            ("tracestate", ""),
-            ("tracestate", "rw=frontend"),
-            ("tracestate", "  "),
-        ];
-
-        let ctx = W3CTraceContext::decode_headers(headers).unwrap();
-        assert_eq!(ctx.tracestate(), Some("rw=frontend"));
-    }
-
-    #[test]
-    fn w3c_trace_context_decode_headers_all_empty_tracestate() {
-        let headers = vec![
-            (
-                "traceparent",
-                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-            ),
-            ("tracestate", ""),
-            ("tracestate", "  "),
-        ];
-
-        let ctx = W3CTraceContext::decode_headers(headers).unwrap();
-        assert_eq!(ctx.tracestate(), None);
-    }
-
-    #[test]
-    fn w3c_trace_context_header_roundtrip() {
-        let original = W3CTraceContext::new(SpanContext::new(TraceId(42), SpanId(99)))
-            .with_tracestate("vendor=value,other=data");
-
-        let headers = original.encode_headers();
-        let header_refs: Vec<(&str, &str)> = headers
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
-
-        let decoded = W3CTraceContext::decode_headers(header_refs).unwrap();
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    fn w3c_trace_context_from_span_context() {
-        let span_ctx = SpanContext::new(TraceId(1), SpanId(2));
-        let w3c_ctx: W3CTraceContext = span_ctx.into();
-        assert_eq!(w3c_ctx.span_context, span_ctx);
-        assert_eq!(w3c_ctx.tracestate(), None);
+    fn root_span_context_cannot_encode_traceparent() {
+        let root_ctx = SpanContext::root(trace_id(1));
+        assert!(root_ctx.encode_traceparent().is_none());
     }
 }

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -6,6 +6,8 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use serde::ser::SerializeStruct;
+
 use crate::Span;
 use crate::local::local_span_stack::LOCAL_SPAN_STACK;
 
@@ -534,18 +536,36 @@ impl SpanContext {
 
 impl serde::Serialize for SpanContext {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let traceparent = self.encode_traceparent().ok_or_else(|| {
-            serde::ser::Error::custom("span context has no span id for traceparent")
-        })?;
-        traceparent.serialize(serializer)
+        let mut fields = serializer.serialize_struct("SpanContext", 4)?;
+        fields.serialize_field("trace_id", &self.trace_id)?;
+        fields.serialize_field("span_id", &self.span_id)?;
+        fields.serialize_field("trace_flags", &self.trace_flags.to_u8())?;
+        fields.serialize_field("trace_state", &self.trace_state.as_header_value())?;
+        fields.end()
     }
 }
 
 impl<'de> serde::Deserialize<'de> for SpanContext {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        SpanContext::decode_traceparent(&s)
-            .ok_or_else(|| serde::de::Error::custom("invalid w3c traceparent"))
+        #[derive(serde::Deserialize)]
+        struct Fields {
+            trace_id: TraceId,
+            span_id: Option<SpanId>,
+            trace_flags: u8,
+            trace_state: Option<String>,
+        }
+
+        let fields = Fields::deserialize(deserializer)?;
+
+        Ok(SpanContext {
+            trace_id: fields.trace_id,
+            span_id: fields.span_id,
+            trace_flags: TraceFlags::new(fields.trace_flags),
+            trace_state: fields
+                .trace_state
+                .map(TraceState::from_header_value)
+                .unwrap_or(TraceState::EMPTY),
+        })
     }
 }
 
@@ -754,5 +774,36 @@ mod tests {
     fn root_span_context_cannot_encode_traceparent() {
         let root_ctx = SpanContext::root(trace_id(1));
         assert!(root_ctx.encode_traceparent().is_none());
+    }
+
+    #[test]
+    fn span_context_serde_preserves_trace_state_and_root() {
+        let ctx = SpanContext::root(trace_id(1))
+            .with_trace_flags(TraceFlags::new(0x03))
+            .with_trace_state("vendor=value");
+
+        let json = serde_json::to_string(&ctx).unwrap();
+        let decoded: SpanContext = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, ctx);
+        assert_eq!(decoded.span_id(), None);
+        assert_eq!(decoded.trace_flags().to_u8(), 0x03);
+        assert_eq!(decoded.trace_state(), Some("vendor=value"));
+    }
+
+    #[test]
+    fn span_context_serde_rejects_zero_ids() {
+        assert!(
+            serde_json::from_str::<SpanContext>(
+                r#"{"trace_id":"0","span_id":null,"trace_flags":1,"trace_state":null}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<SpanContext>(
+                r#"{"trace_id":"1","span_id":"0","trace_flags":1,"trace_state":null}"#
+            )
+            .is_err()
+        );
     }
 }

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -15,7 +15,7 @@ thread_local! {
     static LOCAL_ID_GENERATOR: Cell<(u32, u32)> = Cell::new((rand::random(), 0))
 }
 
-/// Error returned when a trace id is malformed or all zeroes.
+/// Error returned when a trace id is malformed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InvalidTraceId;
 
@@ -27,7 +27,7 @@ impl fmt::Display for InvalidTraceId {
 
 impl std::error::Error for InvalidTraceId {}
 
-/// Error returned when a span id is malformed or all zeroes.
+/// Error returned when a span id is malformed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InvalidSpanId;
 
@@ -39,17 +39,17 @@ impl fmt::Display for InvalidSpanId {
 
 impl std::error::Error for InvalidSpanId {}
 
-fn is_all_zero(bytes: &[u8]) -> bool {
-    bytes.iter().all(|byte| *byte == 0)
-}
-
 /// An identifier for a trace, which groups a set of related spans together.
 ///
-/// A valid `TraceId` contains at least one non-zero byte.
+/// `TraceId::INVALID` is all zeroes. Fastrace can carry it internally, but W3C
+/// `traceparent` propagation rejects it.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TraceId(u128);
 
 impl TraceId {
+    /// The all-zero invalid trace id.
+    pub const INVALID: TraceId = TraceId(0);
+
     /// Create a random non-zero `TraceId`.
     ///
     /// # Examples
@@ -70,25 +70,23 @@ impl TraceId {
 
     /// Creates a `TraceId` from bytes.
     ///
-    /// Returns `None` if all bytes are zero.
-    pub fn from_bytes(bytes: [u8; 16]) -> Option<Self> {
-        let value = u128::from_be_bytes(bytes);
-        if value != 0 { Some(Self(value)) } else { None }
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(u128::from_be_bytes(bytes))
     }
 
     /// Creates a `TraceId` from a hexadecimal string.
     ///
     /// The input may contain fewer than 32 hexadecimal characters. Short inputs
     /// are interpreted as if they were left-padded with zeroes. Returns an error
-    /// if the input is empty, longer than 32 hexadecimal characters, contains
-    /// non-hexadecimal characters, or represents all zeroes.
+    /// if the input is empty, longer than 32 hexadecimal characters, or contains
+    /// non-hexadecimal characters.
     pub fn from_hex(hex: &str) -> Result<Self, InvalidTraceId> {
         if hex.is_empty() || hex.len() > 32 {
             return Err(InvalidTraceId);
         }
 
         match u128::from_str_radix(hex, 16) {
-            Ok(value) if value != 0 => Ok(Self(value)),
+            Ok(value) => Ok(Self(value)),
             _ => Err(InvalidTraceId),
         }
     }
@@ -134,11 +132,15 @@ impl<'de> serde::Deserialize<'de> for TraceId {
 
 /// An identifier for a span within a trace.
 ///
-/// A valid `SpanId` is exactly 8 bytes and contains at least one non-zero byte.
+/// `SpanId::INVALID` is all zeroes. Fastrace can carry it internally, but W3C
+/// `traceparent` propagation rejects it.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SpanId([u8; 8]);
 
 impl SpanId {
+    /// The all-zero invalid span id.
+    pub const INVALID: SpanId = SpanId([0; 8]);
+
     /// Create a random non-zero `SpanId`.
     ///
     /// # Examples
@@ -151,32 +153,31 @@ impl SpanId {
     pub fn random() -> Self {
         loop {
             let bytes = rand::random::<u64>().to_be_bytes();
-            if let Some(span_id) = Self::from_bytes(bytes) {
+            let span_id = Self::from_bytes(bytes);
+            if span_id != Self::INVALID {
                 return span_id;
             }
         }
     }
 
     /// Creates a `SpanId` from bytes.
-    ///
-    /// Returns `None` if all bytes are zero.
-    pub fn from_bytes(bytes: [u8; 8]) -> Option<Self> {
-        (!is_all_zero(&bytes)).then_some(Self(bytes))
+    pub const fn from_bytes(bytes: [u8; 8]) -> Self {
+        Self(bytes)
     }
 
     /// Creates a `SpanId` from a hexadecimal string.
     ///
     /// The input may contain fewer than 16 hexadecimal characters. Short inputs
     /// are interpreted as if they were left-padded with zeroes. Returns an error
-    /// if the input is empty, longer than 16 hexadecimal characters, contains
-    /// non-hexadecimal characters, or represents all zeroes.
+    /// if the input is empty, longer than 16 hexadecimal characters, or contains
+    /// non-hexadecimal characters.
     pub fn from_hex(hex: &str) -> Result<Self, InvalidSpanId> {
         if hex.is_empty() || hex.len() > 16 {
             return Err(InvalidSpanId);
         }
 
         match u64::from_str_radix(hex, 16) {
-            Ok(value) if value != 0 => Ok(Self(value.to_be_bytes())),
+            Ok(value) => Ok(Self(value.to_be_bytes())),
             _ => Err(InvalidSpanId),
         }
     }
@@ -199,7 +200,12 @@ impl SpanId {
                 g.set((prefix, suffix));
 
                 let raw = ((prefix as u64) << 32) | (suffix as u64);
-                SpanId::from_bytes(raw.to_be_bytes()).unwrap_or_else(SpanId::random)
+                let span_id = SpanId::from_bytes(raw.to_be_bytes());
+                if span_id == SpanId::INVALID {
+                    SpanId::random()
+                } else {
+                    span_id
+                }
             })
             .unwrap_or_else(|_| SpanId::random())
     }
@@ -343,7 +349,7 @@ impl SpanContext {
     /// W3C `tracestate` header name.
     pub const TRACESTATE_HEADER_NAME: &'static str = "tracestate";
 
-    /// Creates a `SpanContext` from a trace id and a valid parent span id.
+    /// Creates a `SpanContext` from a trace id and a parent span id.
     ///
     /// Use [`SpanContext::root`] or [`SpanContext::random`] when starting a
     /// trace without a remote parent.
@@ -433,6 +439,9 @@ impl SpanContext {
     /// Returns `None` if this context represents a root with no remote parent span id.
     pub fn encode_traceparent(&self) -> Option<String> {
         let span_id = self.span_id?;
+        if self.trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
+            return None;
+        }
         Some(format!(
             "00-{}-{}-{:02x}",
             self.trace_id, span_id, self.trace_flags
@@ -454,9 +463,14 @@ impl SpanContext {
                 if trace_id.len() != 32 || span_id.len() != 16 || trace_flags.len() != 2 {
                     return None;
                 }
+                let trace_id = TraceId::from_hex(trace_id).ok()?;
+                let span_id = SpanId::from_hex(span_id).ok()?;
+                if trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
+                    return None;
+                }
                 Some(Self {
-                    trace_id: TraceId::from_hex(trace_id).ok()?,
-                    span_id: Some(SpanId::from_hex(span_id).ok()?),
+                    trace_id,
+                    span_id: Some(span_id),
                     trace_flags: TraceFlags::new(u8::from_str_radix(trace_flags, 16).ok()?),
                     trace_state: TraceState::EMPTY,
                 })
@@ -576,11 +590,11 @@ mod tests {
     use super::*;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+        TraceId::from_bytes(value.to_be_bytes())
     }
 
     fn span_id(value: u64) -> SpanId {
-        SpanId::from_bytes(value.to_be_bytes()).unwrap()
+        SpanId::from_bytes(value.to_be_bytes())
     }
 
     #[test]
@@ -605,32 +619,48 @@ mod tests {
     }
 
     #[test]
-    fn zero_ids_are_rejected() {
-        assert!(TraceId::from_bytes([0; 16]).is_none());
-        assert!(SpanId::from_bytes([0; 8]).is_none());
-        assert!(TraceId::from_hex("").is_err());
-        assert!(SpanId::from_hex("").is_err());
-        assert!(TraceId::from_hex("0").is_err());
-        assert!(SpanId::from_hex("0").is_err());
-        assert!(TraceId::from_hex("00000000000000000000000000000000").is_err());
-        assert!(SpanId::from_hex("0000000000000000").is_err());
-        assert!(
+    fn invalid_ids_are_representable() {
+        assert_eq!(TraceId::from_bytes([0; 16]), TraceId::INVALID);
+        assert_eq!(SpanId::from_bytes([0; 8]), SpanId::INVALID);
+        assert_eq!(TraceId::from_hex("0").unwrap(), TraceId::INVALID);
+        assert_eq!(SpanId::from_hex("0").unwrap(), SpanId::INVALID);
+        assert_eq!(
+            TraceId::from_hex("00000000000000000000000000000000").unwrap(),
+            TraceId::INVALID
+        );
+        assert_eq!(
+            SpanId::from_hex("0000000000000000").unwrap(),
+            SpanId::INVALID
+        );
+        assert_eq!(
             "00000000000000000000000000000000"
                 .parse::<TraceId>()
-                .is_err()
+                .unwrap(),
+            TraceId::INVALID
         );
-        assert!("0000000000000000".parse::<SpanId>().is_err());
+        assert_eq!(
+            "0000000000000000".parse::<SpanId>().unwrap(),
+            SpanId::INVALID
+        );
+    }
+
+    #[test]
+    fn malformed_ids_are_rejected() {
+        assert!(TraceId::from_hex("").is_err());
+        assert!(SpanId::from_hex("").is_err());
+        assert!(TraceId::from_hex("g").is_err());
+        assert!(SpanId::from_hex("g").is_err());
     }
 
     #[test]
     fn short_hex_ids_are_left_padded() {
         let trace = TraceId::from_hex("abc").unwrap();
         assert_eq!(trace.to_string(), "00000000000000000000000000000abc");
-        assert_eq!(TraceId::from_bytes(0x0abcu128.to_be_bytes()), Some(trace));
+        assert_eq!(TraceId::from_bytes(0x0abcu128.to_be_bytes()), trace);
 
         let span = SpanId::from_hex("abc").unwrap();
         assert_eq!(span.to_string(), "0000000000000abc");
-        assert_eq!(SpanId::from_bytes(0x0abcu64.to_be_bytes()), Some(span));
+        assert_eq!(SpanId::from_bytes(0x0abcu64.to_be_bytes()), span);
 
         assert!(TraceId::from_hex("000000000000000000000000000000001").is_err());
         assert!(SpanId::from_hex("00000000000000001").is_err());
@@ -640,18 +670,18 @@ mod tests {
     fn valid_ids_roundtrip() {
         let trace = TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap();
         assert_eq!(trace.to_string(), "0af7651916cd43dd8448eb211c80319c");
-        assert_eq!(TraceId::from_bytes(trace.to_bytes()), Some(trace));
+        assert_eq!(TraceId::from_bytes(trace.to_bytes()), trace);
         assert_eq!(
             TraceId::from_bytes(0x0af7651916cd43dd8448eb211c80319cu128.to_be_bytes()),
-            Some(trace)
+            trace
         );
 
         let span = SpanId::from_hex("b7ad6b7169203331").unwrap();
         assert_eq!(span.to_string(), "b7ad6b7169203331");
-        assert_eq!(SpanId::from_bytes(span.to_bytes()), Some(span));
+        assert_eq!(SpanId::from_bytes(span.to_bytes()), span);
         assert_eq!(
             SpanId::from_bytes(0xb7ad6b7169203331u64.to_be_bytes()),
-            Some(span)
+            span
         );
     }
 
@@ -777,6 +807,25 @@ mod tests {
     }
 
     #[test]
+    fn invalid_span_context_cannot_encode_traceparent() {
+        assert!(
+            SpanContext::root(TraceId::INVALID)
+                .encode_traceparent()
+                .is_none()
+        );
+        assert!(
+            SpanContext::new(TraceId::INVALID, span_id(1))
+                .encode_traceparent()
+                .is_none()
+        );
+        assert!(
+            SpanContext::new(trace_id(1), SpanId::INVALID)
+                .encode_traceparent()
+                .is_none()
+        );
+    }
+
+    #[test]
     fn span_context_serde_preserves_trace_state_and_root() {
         let ctx = SpanContext::root(trace_id(1))
             .with_trace_flags(TraceFlags::new(0x03))
@@ -792,18 +841,13 @@ mod tests {
     }
 
     #[test]
-    fn span_context_serde_rejects_zero_ids() {
-        assert!(
-            serde_json::from_str::<SpanContext>(
-                r#"{"trace_id":"0","span_id":null,"trace_flags":1,"trace_state":null}"#
-            )
-            .is_err()
-        );
-        assert!(
-            serde_json::from_str::<SpanContext>(
-                r#"{"trace_id":"1","span_id":"0","trace_flags":1,"trace_state":null}"#
-            )
-            .is_err()
-        );
+    fn span_context_serde_preserves_invalid_ids() {
+        let ctx = SpanContext::new(TraceId::INVALID, SpanId::INVALID);
+        let json = serde_json::to_string(&ctx).unwrap();
+        let decoded: SpanContext = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, ctx);
+        assert_eq!(decoded.trace_id(), TraceId::INVALID);
+        assert_eq!(decoded.span_id(), Some(SpanId::INVALID));
     }
 }

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -3,7 +3,6 @@
 use std::cell::Cell;
 use std::fmt;
 use std::rc::Rc;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use serde::ser::SerializeStruct;
@@ -14,30 +13,6 @@ use crate::local::local_span_stack::LOCAL_SPAN_STACK;
 thread_local! {
     static LOCAL_ID_GENERATOR: Cell<(u32, u32)> = Cell::new((rand::random(), 0))
 }
-
-/// Error returned when a trace id is malformed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct InvalidTraceId;
-
-impl fmt::Display for InvalidTraceId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("invalid trace id")
-    }
-}
-
-impl std::error::Error for InvalidTraceId {}
-
-/// Error returned when a span id is malformed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct InvalidSpanId;
-
-impl fmt::Display for InvalidSpanId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("invalid span id")
-    }
-}
-
-impl std::error::Error for InvalidSpanId {}
 
 /// An identifier for a trace, which groups a set of related spans together.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -64,30 +39,26 @@ impl TraceId {
 
     /// Creates a `TraceId` from bytes.
     ///
-    /// Returns an error if the bytes are all zeroes.
-    pub const fn from_bytes(bytes: [u8; 16]) -> Result<Self, InvalidTraceId> {
+    /// Returns `None` if the bytes are all zeroes.
+    pub const fn from_bytes(bytes: [u8; 16]) -> Option<Self> {
         let value = u128::from_be_bytes(bytes);
-        if value == 0 {
-            Err(InvalidTraceId)
-        } else {
-            Ok(Self(value))
-        }
+        if value == 0 { None } else { Some(Self(value)) }
     }
 
     /// Creates a `TraceId` from a hexadecimal string.
     ///
     /// The input may contain fewer than 32 hexadecimal characters. Short inputs
-    /// are interpreted as if they were left-padded with zeroes. Returns an error
+    /// are interpreted as if they were left-padded with zeroes. Returns `None`
     /// if the input is empty, longer than 32 hexadecimal characters, all zeroes,
     /// or contains non-hexadecimal characters.
-    pub fn from_hex(hex: &str) -> Result<Self, InvalidTraceId> {
+    pub fn from_hex(hex: &str) -> Option<Self> {
         if hex.is_empty() || hex.len() > 32 {
-            return Err(InvalidTraceId);
+            return None;
         }
 
         match u128::from_str_radix(hex, 16) {
-            Ok(0) | Err(_) => Err(InvalidTraceId),
-            Ok(value) => Ok(Self(value)),
+            Ok(0) | Err(_) => None,
+            Ok(value) => Some(Self(value)),
         }
     }
 
@@ -109,14 +80,6 @@ impl fmt::Debug for TraceId {
     }
 }
 
-impl FromStr for TraceId {
-    type Err = InvalidTraceId;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_hex(s)
-    }
-}
-
 impl serde::Serialize for TraceId {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.to_string())
@@ -126,7 +89,7 @@ impl serde::Serialize for TraceId {
 impl<'de> serde::Deserialize<'de> for TraceId {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        TraceId::from_hex(&s).map_err(serde::de::Error::custom)
+        TraceId::from_hex(&s).ok_or_else(|| serde::de::Error::custom("invalid trace id"))
     }
 }
 
@@ -155,29 +118,29 @@ impl SpanId {
 
     /// Creates a `SpanId` from bytes.
     ///
-    /// Returns an error if the bytes are all zeroes.
-    pub const fn from_bytes(bytes: [u8; 8]) -> Result<Self, InvalidSpanId> {
+    /// Returns `None` if the bytes are all zeroes.
+    pub const fn from_bytes(bytes: [u8; 8]) -> Option<Self> {
         if u64::from_be_bytes(bytes) == 0 {
-            Err(InvalidSpanId)
+            None
         } else {
-            Ok(Self(bytes))
+            Some(Self(bytes))
         }
     }
 
     /// Creates a `SpanId` from a hexadecimal string.
     ///
     /// The input may contain fewer than 16 hexadecimal characters. Short inputs
-    /// are interpreted as if they were left-padded with zeroes. Returns an error
+    /// are interpreted as if they were left-padded with zeroes. Returns `None`
     /// if the input is empty, longer than 16 hexadecimal characters, all zeroes,
     /// or contains non-hexadecimal characters.
-    pub fn from_hex(hex: &str) -> Result<Self, InvalidSpanId> {
+    pub fn from_hex(hex: &str) -> Option<Self> {
         if hex.is_empty() || hex.len() > 16 {
-            return Err(InvalidSpanId);
+            return None;
         }
 
         match u64::from_str_radix(hex, 16) {
-            Ok(0) | Err(_) => Err(InvalidSpanId),
-            Ok(value) => Ok(Self(value.to_be_bytes())),
+            Ok(0) | Err(_) => None,
+            Ok(value) => Some(Self(value.to_be_bytes())),
         }
     }
 
@@ -215,14 +178,6 @@ impl fmt::Display for SpanId {
     }
 }
 
-impl FromStr for SpanId {
-    type Err = InvalidSpanId;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_hex(s)
-    }
-}
-
 impl serde::Serialize for SpanId {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.to_string())
@@ -232,7 +187,7 @@ impl serde::Serialize for SpanId {
 impl<'de> serde::Deserialize<'de> for SpanId {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        SpanId::from_hex(&s).map_err(serde::de::Error::custom)
+        SpanId::from_hex(&s).ok_or_else(|| serde::de::Error::custom("invalid span id"))
     }
 }
 
@@ -423,8 +378,8 @@ impl SpanContext {
                 if trace_id.len() != 32 || span_id.len() != 16 || trace_flags.len() != 2 {
                     return None;
                 }
-                let trace_id = TraceId::from_hex(trace_id).ok()?;
-                let span_id = SpanId::from_hex(span_id).ok()?;
+                let trace_id = TraceId::from_hex(trace_id)?;
+                let span_id = SpanId::from_hex(span_id)?;
                 Some(Self {
                     trace_id,
                     span_id: Some(span_id),
@@ -577,26 +532,20 @@ mod tests {
 
     #[test]
     fn zero_ids_are_rejected() {
-        assert!(TraceId::from_bytes([0; 16]).is_err());
-        assert!(SpanId::from_bytes([0; 8]).is_err());
-        assert!(TraceId::from_hex("0").is_err());
-        assert!(SpanId::from_hex("0").is_err());
-        assert!(TraceId::from_hex("00000000000000000000000000000000").is_err());
-        assert!(SpanId::from_hex("0000000000000000").is_err());
-        assert!(
-            "00000000000000000000000000000000"
-                .parse::<TraceId>()
-                .is_err()
-        );
-        assert!("0000000000000000".parse::<SpanId>().is_err());
+        assert!(TraceId::from_bytes([0; 16]).is_none());
+        assert!(SpanId::from_bytes([0; 8]).is_none());
+        assert!(TraceId::from_hex("0").is_none());
+        assert!(SpanId::from_hex("0").is_none());
+        assert!(TraceId::from_hex("00000000000000000000000000000000").is_none());
+        assert!(SpanId::from_hex("0000000000000000").is_none());
     }
 
     #[test]
     fn malformed_ids_are_rejected() {
-        assert!(TraceId::from_hex("").is_err());
-        assert!(SpanId::from_hex("").is_err());
-        assert!(TraceId::from_hex("g").is_err());
-        assert!(SpanId::from_hex("g").is_err());
+        assert!(TraceId::from_hex("").is_none());
+        assert!(SpanId::from_hex("").is_none());
+        assert!(TraceId::from_hex("g").is_none());
+        assert!(SpanId::from_hex("g").is_none());
     }
 
     #[test]
@@ -612,8 +561,8 @@ mod tests {
         assert_eq!(span.to_string(), "0000000000000abc");
         assert_eq!(SpanId::from_bytes(0x0abcu64.to_be_bytes()).unwrap(), span);
 
-        assert!(TraceId::from_hex("000000000000000000000000000000001").is_err());
-        assert!(SpanId::from_hex("00000000000000001").is_err());
+        assert!(TraceId::from_hex("000000000000000000000000000000001").is_none());
+        assert!(SpanId::from_hex("00000000000000001").is_none());
     }
 
     #[test]

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -286,12 +286,6 @@ pub struct SpanContext {
 }
 
 impl SpanContext {
-    /// W3C `traceparent` header name.
-    pub const TRACEPARENT_HEADER_NAME: &'static str = "traceparent";
-
-    /// W3C `tracestate` header name.
-    pub const TRACESTATE_HEADER_NAME: &'static str = "tracestate";
-
     /// Creates a `SpanContext` from a trace id and a parent span id.
     ///
     /// Use [`SpanContext::random`] when starting a trace with a generated trace
@@ -689,12 +683,6 @@ mod tests {
 
         let ctx = ctx.with_trace_state("");
         assert_eq!(ctx.trace_state.as_header_value(), None);
-    }
-
-    #[test]
-    fn span_context_header_name_constants() {
-        assert_eq!(SpanContext::TRACEPARENT_HEADER_NAME, "traceparent");
-        assert_eq!(SpanContext::TRACESTATE_HEADER_NAME, "tracestate");
     }
 
     #[test]

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -40,16 +40,10 @@ impl fmt::Display for InvalidSpanId {
 impl std::error::Error for InvalidSpanId {}
 
 /// An identifier for a trace, which groups a set of related spans together.
-///
-/// `TraceId::INVALID` is all zeroes. Fastrace can carry it internally, but W3C
-/// `traceparent` propagation rejects it.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TraceId(u128);
 
 impl TraceId {
-    /// The all-zero invalid trace id.
-    pub const INVALID: TraceId = TraceId(0);
-
     /// Create a random non-zero `TraceId`.
     ///
     /// # Examples
@@ -70,24 +64,30 @@ impl TraceId {
 
     /// Creates a `TraceId` from bytes.
     ///
-    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
-        Self(u128::from_be_bytes(bytes))
+    /// Returns an error if the bytes are all zeroes.
+    pub const fn from_bytes(bytes: [u8; 16]) -> Result<Self, InvalidTraceId> {
+        let value = u128::from_be_bytes(bytes);
+        if value == 0 {
+            Err(InvalidTraceId)
+        } else {
+            Ok(Self(value))
+        }
     }
 
     /// Creates a `TraceId` from a hexadecimal string.
     ///
     /// The input may contain fewer than 32 hexadecimal characters. Short inputs
     /// are interpreted as if they were left-padded with zeroes. Returns an error
-    /// if the input is empty, longer than 32 hexadecimal characters, or contains
-    /// non-hexadecimal characters.
+    /// if the input is empty, longer than 32 hexadecimal characters, all zeroes,
+    /// or contains non-hexadecimal characters.
     pub fn from_hex(hex: &str) -> Result<Self, InvalidTraceId> {
         if hex.is_empty() || hex.len() > 32 {
             return Err(InvalidTraceId);
         }
 
         match u128::from_str_radix(hex, 16) {
+            Ok(0) | Err(_) => Err(InvalidTraceId),
             Ok(value) => Ok(Self(value)),
-            _ => Err(InvalidTraceId),
         }
     }
 
@@ -131,16 +131,10 @@ impl<'de> serde::Deserialize<'de> for TraceId {
 }
 
 /// An identifier for a span within a trace.
-///
-/// `SpanId::INVALID` is all zeroes. Fastrace can carry it internally, but W3C
-/// `traceparent` propagation rejects it.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SpanId([u8; 8]);
 
 impl SpanId {
-    /// The all-zero invalid span id.
-    pub const INVALID: SpanId = SpanId([0; 8]);
-
     /// Create a random non-zero `SpanId`.
     ///
     /// # Examples
@@ -153,32 +147,37 @@ impl SpanId {
     pub fn random() -> Self {
         loop {
             let bytes = rand::random::<u64>().to_be_bytes();
-            let span_id = Self::from_bytes(bytes);
-            if span_id != Self::INVALID {
-                return span_id;
+            if u64::from_be_bytes(bytes) != 0 {
+                return Self(bytes);
             }
         }
     }
 
     /// Creates a `SpanId` from bytes.
-    pub const fn from_bytes(bytes: [u8; 8]) -> Self {
-        Self(bytes)
+    ///
+    /// Returns an error if the bytes are all zeroes.
+    pub const fn from_bytes(bytes: [u8; 8]) -> Result<Self, InvalidSpanId> {
+        if u64::from_be_bytes(bytes) == 0 {
+            Err(InvalidSpanId)
+        } else {
+            Ok(Self(bytes))
+        }
     }
 
     /// Creates a `SpanId` from a hexadecimal string.
     ///
     /// The input may contain fewer than 16 hexadecimal characters. Short inputs
     /// are interpreted as if they were left-padded with zeroes. Returns an error
-    /// if the input is empty, longer than 16 hexadecimal characters, or contains
-    /// non-hexadecimal characters.
+    /// if the input is empty, longer than 16 hexadecimal characters, all zeroes,
+    /// or contains non-hexadecimal characters.
     pub fn from_hex(hex: &str) -> Result<Self, InvalidSpanId> {
         if hex.is_empty() || hex.len() > 16 {
             return Err(InvalidSpanId);
         }
 
         match u64::from_str_radix(hex, 16) {
+            Ok(0) | Err(_) => Err(InvalidSpanId),
             Ok(value) => Ok(Self(value.to_be_bytes())),
-            _ => Err(InvalidSpanId),
         }
     }
 
@@ -200,11 +199,10 @@ impl SpanId {
                 g.set((prefix, suffix));
 
                 let raw = ((prefix as u64) << 32) | (suffix as u64);
-                let span_id = SpanId::from_bytes(raw.to_be_bytes());
-                if span_id == SpanId::INVALID {
+                if raw == 0 {
                     SpanId::random()
                 } else {
-                    span_id
+                    SpanId(raw.to_be_bytes())
                 }
             })
             .unwrap_or_else(|_| SpanId::random())
@@ -404,9 +402,6 @@ impl SpanContext {
     /// Returns `None` if this context represents a root with no remote parent span id.
     pub fn encode_traceparent(&self) -> Option<String> {
         let span_id = self.span_id?;
-        if self.trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
-            return None;
-        }
         Some(format!(
             "00-{}-{}-{:02x}",
             self.trace_id, span_id, self.trace_flags
@@ -430,9 +425,6 @@ impl SpanContext {
                 }
                 let trace_id = TraceId::from_hex(trace_id).ok()?;
                 let span_id = SpanId::from_hex(span_id).ok()?;
-                if trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
-                    return None;
-                }
                 Some(Self {
                     trace_id,
                     span_id: Some(span_id),
@@ -555,11 +547,11 @@ mod tests {
     use super::*;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes())
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
     }
 
     fn span_id(value: u64) -> SpanId {
-        SpanId::from_bytes(value.to_be_bytes())
+        SpanId::from_bytes(value.to_be_bytes()).unwrap()
     }
 
     #[test]
@@ -584,29 +576,19 @@ mod tests {
     }
 
     #[test]
-    fn invalid_ids_are_representable() {
-        assert_eq!(TraceId::from_bytes([0; 16]), TraceId::INVALID);
-        assert_eq!(SpanId::from_bytes([0; 8]), SpanId::INVALID);
-        assert_eq!(TraceId::from_hex("0").unwrap(), TraceId::INVALID);
-        assert_eq!(SpanId::from_hex("0").unwrap(), SpanId::INVALID);
-        assert_eq!(
-            TraceId::from_hex("00000000000000000000000000000000").unwrap(),
-            TraceId::INVALID
-        );
-        assert_eq!(
-            SpanId::from_hex("0000000000000000").unwrap(),
-            SpanId::INVALID
-        );
-        assert_eq!(
+    fn zero_ids_are_rejected() {
+        assert!(TraceId::from_bytes([0; 16]).is_err());
+        assert!(SpanId::from_bytes([0; 8]).is_err());
+        assert!(TraceId::from_hex("0").is_err());
+        assert!(SpanId::from_hex("0").is_err());
+        assert!(TraceId::from_hex("00000000000000000000000000000000").is_err());
+        assert!(SpanId::from_hex("0000000000000000").is_err());
+        assert!(
             "00000000000000000000000000000000"
                 .parse::<TraceId>()
-                .unwrap(),
-            TraceId::INVALID
+                .is_err()
         );
-        assert_eq!(
-            "0000000000000000".parse::<SpanId>().unwrap(),
-            SpanId::INVALID
-        );
+        assert!("0000000000000000".parse::<SpanId>().is_err());
     }
 
     #[test]
@@ -621,11 +603,14 @@ mod tests {
     fn short_hex_ids_are_left_padded() {
         let trace = TraceId::from_hex("abc").unwrap();
         assert_eq!(trace.to_string(), "00000000000000000000000000000abc");
-        assert_eq!(TraceId::from_bytes(0x0abcu128.to_be_bytes()), trace);
+        assert_eq!(
+            TraceId::from_bytes(0x0abcu128.to_be_bytes()).unwrap(),
+            trace
+        );
 
         let span = SpanId::from_hex("abc").unwrap();
         assert_eq!(span.to_string(), "0000000000000abc");
-        assert_eq!(SpanId::from_bytes(0x0abcu64.to_be_bytes()), span);
+        assert_eq!(SpanId::from_bytes(0x0abcu64.to_be_bytes()).unwrap(), span);
 
         assert!(TraceId::from_hex("000000000000000000000000000000001").is_err());
         assert!(SpanId::from_hex("00000000000000001").is_err());
@@ -635,17 +620,17 @@ mod tests {
     fn valid_ids_roundtrip() {
         let trace = TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap();
         assert_eq!(trace.to_string(), "0af7651916cd43dd8448eb211c80319c");
-        assert_eq!(TraceId::from_bytes(trace.to_bytes()), trace);
+        assert_eq!(TraceId::from_bytes(trace.to_bytes()).unwrap(), trace);
         assert_eq!(
-            TraceId::from_bytes(0x0af7651916cd43dd8448eb211c80319cu128.to_be_bytes()),
+            TraceId::from_bytes(0x0af7651916cd43dd8448eb211c80319cu128.to_be_bytes()).unwrap(),
             trace
         );
 
         let span = SpanId::from_hex("b7ad6b7169203331").unwrap();
         assert_eq!(span.to_string(), "b7ad6b7169203331");
-        assert_eq!(SpanId::from_bytes(span.to_bytes()), span);
+        assert_eq!(SpanId::from_bytes(span.to_bytes()).unwrap(), span);
         assert_eq!(
-            SpanId::from_bytes(0xb7ad6b7169203331u64.to_be_bytes()),
+            SpanId::from_bytes(0xb7ad6b7169203331u64.to_be_bytes()).unwrap(),
             span
         );
     }
@@ -775,25 +760,6 @@ mod tests {
     }
 
     #[test]
-    fn invalid_span_context_cannot_encode_traceparent() {
-        assert!(
-            SpanContext::root(TraceId::INVALID)
-                .encode_traceparent()
-                .is_none()
-        );
-        assert!(
-            SpanContext::new(TraceId::INVALID, span_id(1))
-                .encode_traceparent()
-                .is_none()
-        );
-        assert!(
-            SpanContext::new(trace_id(1), SpanId::INVALID)
-                .encode_traceparent()
-                .is_none()
-        );
-    }
-
-    #[test]
     fn span_context_serde_preserves_trace_state_and_root() {
         let ctx = SpanContext::root(trace_id(1))
             .with_trace_flags(TraceFlags::new(0x03))
@@ -809,13 +775,11 @@ mod tests {
     }
 
     #[test]
-    fn span_context_serde_preserves_invalid_ids() {
-        let ctx = SpanContext::new(TraceId::INVALID, SpanId::INVALID);
-        let json = serde_json::to_string(&ctx).unwrap();
-        let decoded: SpanContext = serde_json::from_str(&json).unwrap();
+    fn span_context_serde_rejects_zero_ids() {
+        let zero_trace = r#"{"trace_id":"00000000000000000000000000000000","span_id":null,"trace_flags":1,"trace_state":null}"#;
+        assert!(serde_json::from_str::<SpanContext>(zero_trace).is_err());
 
-        assert_eq!(decoded, ctx);
-        assert_eq!(decoded.trace_id, TraceId::INVALID);
-        assert_eq!(decoded.span_id, Some(SpanId::INVALID));
+        let zero_span = r#"{"trace_id":"00000000000000000000000000000001","span_id":"0000000000000000","trace_flags":1,"trace_state":null}"#;
+        assert!(serde_json::from_str::<SpanContext>(zero_span).is_err());
     }
 }

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -305,11 +305,6 @@ impl TraceState {
     /// An empty tracestate.
     pub const EMPTY: TraceState = TraceState(None);
 
-    /// Creates an empty tracestate.
-    pub const fn empty() -> Self {
-        Self::EMPTY
-    }
-
     /// Creates a tracestate from a header value.
     ///
     /// Empty strings are normalized to `None`.
@@ -325,11 +320,6 @@ impl TraceState {
     /// Returns the header value if this tracestate is present.
     pub fn as_header_value(&self) -> Option<&str> {
         self.0.as_deref()
-    }
-
-    /// Returns `true` when no tracestate is present.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_none()
     }
 }
 
@@ -384,31 +374,6 @@ impl SpanContext {
     pub fn random() -> Self {
         Self::root(TraceId::random())
             .with_trace_flags(TraceFlags::SAMPLED.with_random_trace_id(true))
-    }
-
-    /// Returns the trace id.
-    pub fn trace_id(&self) -> TraceId {
-        self.trace_id
-    }
-
-    /// Returns the parent or linked span id, if present.
-    pub fn span_id(&self) -> Option<SpanId> {
-        self.span_id
-    }
-
-    /// Returns the trace flags.
-    pub fn trace_flags(&self) -> TraceFlags {
-        self.trace_flags
-    }
-
-    /// Returns the tracestate header value, if present.
-    pub fn trace_state(&self) -> Option<&str> {
-        self.trace_state.as_header_value()
-    }
-
-    /// Returns `true` when the sampled trace flag is set.
-    pub fn is_sampled(&self) -> bool {
-        self.trace_flags.is_sampled()
     }
 
     /// Sets the sampled flag of the `SpanContext`.
@@ -695,8 +660,11 @@ mod tests {
 
         assert_eq!(ctx.trace_id, trace_id(0x0af7651916cd43dd8448eb211c80319c));
         assert_eq!(ctx.span_id, Some(span_id(0xb7ad6b7169203331)));
-        assert!(ctx.is_sampled());
-        assert_eq!(ctx.trace_state(), Some("rw=frontend,congo=t61rcWkgMzE"));
+        assert!(ctx.trace_flags.is_sampled());
+        assert_eq!(
+            ctx.trace_state.as_header_value(),
+            Some("rw=frontend,congo=t61rcWkgMzE")
+        );
     }
 
     #[test]
@@ -706,14 +674,14 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(ctx.trace_state(), None);
+        assert_eq!(ctx.trace_state.as_header_value(), None);
     }
 
     #[test]
     fn span_context_empty_tracestate() {
         let ctx = SpanContext::new(trace_id(1), span_id(2)).with_trace_state("");
 
-        assert_eq!(ctx.trace_state(), None);
+        assert_eq!(ctx.trace_state.as_header_value(), None);
     }
 
     #[test]
@@ -745,13 +713,13 @@ mod tests {
         .unwrap()
         .with_trace_state("rw=frontend");
 
-        assert!(original.trace_flags().is_sampled());
-        assert!(original.trace_flags().is_random_trace_id());
+        assert!(original.trace_flags.is_sampled());
+        assert!(original.trace_flags.is_random_trace_id());
 
         let traceparent = original.encode_traceparent().unwrap();
         let decoded = SpanContext::decode_traceparent(&traceparent)
             .unwrap()
-            .with_trace_state(original.trace_state().unwrap());
+            .with_trace_state(original.trace_state.as_header_value().unwrap());
 
         assert_eq!(original, decoded);
     }
@@ -762,7 +730,7 @@ mod tests {
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
         )
         .unwrap();
-        assert!(sampled.trace_flags().is_sampled());
+        assert!(sampled.trace_flags.is_sampled());
         assert_eq!(
             sampled.encode_traceparent().unwrap(),
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
@@ -772,7 +740,7 @@ mod tests {
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00",
         )
         .unwrap();
-        assert!(!not_sampled.trace_flags().is_sampled());
+        assert!(!not_sampled.trace_flags.is_sampled());
         assert_eq!(
             not_sampled.encode_traceparent().unwrap(),
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
@@ -782,16 +750,16 @@ mod tests {
     #[test]
     fn span_context_with_tracestate() {
         let ctx = SpanContext::new(trace_id(1), span_id(2));
-        assert_eq!(ctx.trace_state(), None);
+        assert_eq!(ctx.trace_state.as_header_value(), None);
 
         let ctx = ctx.with_trace_state("rw=frontend");
-        assert_eq!(ctx.trace_state(), Some("rw=frontend"));
+        assert_eq!(ctx.trace_state.as_header_value(), Some("rw=frontend"));
 
         let ctx = ctx.with_trace_state("rw=backend");
-        assert_eq!(ctx.trace_state(), Some("rw=backend"));
+        assert_eq!(ctx.trace_state.as_header_value(), Some("rw=backend"));
 
         let ctx = ctx.with_trace_state("");
-        assert_eq!(ctx.trace_state(), None);
+        assert_eq!(ctx.trace_state.as_header_value(), None);
     }
 
     #[test]
@@ -835,9 +803,9 @@ mod tests {
         let decoded: SpanContext = serde_json::from_str(&json).unwrap();
 
         assert_eq!(decoded, ctx);
-        assert_eq!(decoded.span_id(), None);
-        assert_eq!(decoded.trace_flags().to_u8(), 0x03);
-        assert_eq!(decoded.trace_state(), Some("vendor=value"));
+        assert_eq!(decoded.span_id, None);
+        assert_eq!(decoded.trace_flags.to_u8(), 0x03);
+        assert_eq!(decoded.trace_state.as_header_value(), Some("vendor=value"));
     }
 
     #[test]
@@ -847,7 +815,7 @@ mod tests {
         let decoded: SpanContext = serde_json::from_str(&json).unwrap();
 
         assert_eq!(decoded, ctx);
-        assert_eq!(decoded.trace_id(), TraceId::INVALID);
-        assert_eq!(decoded.span_id(), Some(SpanId::INVALID));
+        assert_eq!(decoded.trace_id, TraceId::INVALID);
+        assert_eq!(decoded.span_id, Some(SpanId::INVALID));
     }
 }

--- a/fastrace/src/collector/id.rs
+++ b/fastrace/src/collector/id.rs
@@ -294,8 +294,9 @@ impl SpanContext {
 
     /// Creates a `SpanContext` from a trace id and a parent span id.
     ///
-    /// Use [`SpanContext::root`] or [`SpanContext::random`] when starting a
-    /// trace without a remote parent.
+    /// Use [`SpanContext::random`] when starting a trace with a generated trace
+    /// id and no remote parent. If the trace id comes from another source, set
+    /// `span_id` to `None` explicitly.
     pub fn new(trace_id: TraceId, span_id: SpanId) -> Self {
         Self {
             trace_id,
@@ -305,17 +306,7 @@ impl SpanContext {
         }
     }
 
-    /// Creates a root `SpanContext` with no remote parent span.
-    pub fn root(trace_id: TraceId) -> Self {
-        Self {
-            trace_id,
-            span_id: None,
-            trace_flags: TraceFlags::SAMPLED,
-            trace_state: TraceState::EMPTY,
-        }
-    }
-
-    /// Create a new root `SpanContext` with a random trace id and no remote parent.
+    /// Creates a new `SpanContext` with a random trace id and no remote parent.
     ///
     /// # Examples
     ///
@@ -325,8 +316,12 @@ impl SpanContext {
     /// let root = Span::root("root", SpanContext::random());
     /// ```
     pub fn random() -> Self {
-        Self::root(TraceId::random())
-            .with_trace_flags(TraceFlags::SAMPLED.with_random_trace_id(true))
+        Self {
+            trace_id: TraceId::random(),
+            span_id: None,
+            trace_flags: TraceFlags::SAMPLED.with_random_trace_id(true),
+            trace_state: TraceState::EMPTY,
+        }
     }
 
     /// Sets the sampled flag of the `SpanContext`.
@@ -354,7 +349,7 @@ impl SpanContext {
 
     /// Encodes this span context into a W3C `traceparent` header value.
     ///
-    /// Returns `None` if this context represents a root with no remote parent span id.
+    /// Returns `None` if this context has no span id.
     pub fn encode_traceparent(&self) -> Option<String> {
         let span_id = self.span_id?;
         Some(format!(
@@ -703,16 +698,24 @@ mod tests {
     }
 
     #[test]
-    fn root_span_context_cannot_encode_traceparent() {
-        let root_ctx = SpanContext::root(trace_id(1));
+    fn span_context_without_span_id_cannot_encode_traceparent() {
+        let root_ctx = SpanContext {
+            trace_id: trace_id(1),
+            span_id: None,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+        };
         assert!(root_ctx.encode_traceparent().is_none());
     }
 
     #[test]
-    fn span_context_serde_preserves_trace_state_and_root() {
-        let ctx = SpanContext::root(trace_id(1))
-            .with_trace_flags(TraceFlags::new(0x03))
-            .with_trace_state("vendor=value");
+    fn span_context_serde_preserves_trace_state_and_missing_span_id() {
+        let ctx = SpanContext {
+            trace_id: trace_id(1),
+            span_id: None,
+            trace_flags: TraceFlags::new(0x03),
+            trace_state: TraceState::from_header_value("vendor=value"),
+        };
 
         let json = serde_json::to_string(&ctx).unwrap();
         let decoded: SpanContext = serde_json::from_str(&json).unwrap();

--- a/fastrace/src/collector/mod.rs
+++ b/fastrace/src/collector/mod.rs
@@ -146,11 +146,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            span_context.trace_id(),
+            span_context.trace_id,
             TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap()
         );
         assert_eq!(
-            span_context.span_id(),
+            span_context.span_id,
             Some(SpanId::from_hex("b7ad6b7169203331").unwrap())
         );
 
@@ -172,6 +172,7 @@ mod tests {
                 "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00",
             )
             .unwrap()
+            .trace_flags
             .is_sampled()
         );
         assert!(
@@ -179,6 +180,7 @@ mod tests {
                 "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
             )
             .unwrap()
+            .trace_flags
             .is_sampled()
         );
         assert!(
@@ -186,6 +188,7 @@ mod tests {
                 "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-10",
             )
             .unwrap()
+            .trace_flags
             .is_sampled()
         );
     }

--- a/fastrace/src/collector/mod.rs
+++ b/fastrace/src/collector/mod.rs
@@ -20,8 +20,6 @@ pub(crate) use global_collector::GlobalCollect;
 #[cfg(test)]
 pub(crate) use global_collector::MockGlobalCollect;
 pub use global_collector::Reporter;
-pub use id::InvalidSpanId;
-pub use id::InvalidTraceId;
 pub use id::SpanContext;
 pub use id::SpanId;
 pub use id::TraceFlags;

--- a/fastrace/src/collector/mod.rs
+++ b/fastrace/src/collector/mod.rs
@@ -20,6 +20,8 @@ pub(crate) use global_collector::GlobalCollect;
 #[cfg(test)]
 pub(crate) use global_collector::MockGlobalCollect;
 pub use global_collector::Reporter;
+pub use id::InvalidSpanId;
+pub use id::InvalidTraceId;
 pub use id::SpanContext;
 pub use id::SpanId;
 pub use id::TraceFlags;

--- a/fastrace/src/collector/mod.rs
+++ b/fastrace/src/collector/mod.rs
@@ -22,8 +22,9 @@ pub(crate) use global_collector::MockGlobalCollect;
 pub use global_collector::Reporter;
 pub use id::SpanContext;
 pub use id::SpanId;
+pub use id::TraceFlags;
 pub use id::TraceId;
-pub use id::W3CTraceContext;
+pub use id::TraceState;
 #[doc(hidden)]
 pub use test_reporter::TestReporter;
 
@@ -43,11 +44,13 @@ pub enum SpanSet {
 
 /// A record of a span that includes all the information about the span,
 /// such as its identifiers, timing information, name, and associated properties.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SpanRecord {
     pub trace_id: TraceId,
     pub span_id: SpanId,
-    pub parent_id: SpanId,
+    pub parent_id: Option<SpanId>,
+    pub trace_flags: TraceFlags,
+    pub trace_state: TraceState,
     pub begin_time_unix_ns: u64,
     pub duration_ns: u64,
     pub name: Cow<'static, str>,
@@ -65,10 +68,12 @@ pub struct EventRecord {
 }
 
 #[doc(hidden)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CollectToken {
     pub trace_id: TraceId,
-    pub parent_id: SpanId,
+    pub parent_id: Option<SpanId>,
+    pub trace_flags: TraceFlags,
+    pub trace_state: TraceState,
     pub collect_id: usize,
     pub is_root: bool,
     pub is_sampled: bool,
@@ -136,45 +141,52 @@ mod tests {
 
     #[test]
     fn w3c_traceparent() {
-        let span_context = SpanContext::decode_w3c_traceparent(
+        let span_context = SpanContext::decode_traceparent(
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
         )
         .unwrap();
         assert_eq!(
-            span_context.trace_id,
-            TraceId(0x0af7651916cd43dd8448eb211c80319c)
+            span_context.trace_id(),
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap()
         );
-        assert_eq!(span_context.span_id, SpanId(0xb7ad6b7169203331));
+        assert_eq!(
+            span_context.span_id(),
+            Some(SpanId::from_hex("b7ad6b7169203331").unwrap())
+        );
 
         assert_eq!(
-            span_context.encode_w3c_traceparent(),
+            span_context.encode_traceparent().unwrap(),
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
         );
         assert_eq!(
-            span_context.sampled(false).encode_w3c_traceparent(),
+            span_context
+                .clone()
+                .with_trace_flags(TraceFlags::NOT_SAMPLED)
+                .encode_traceparent()
+                .unwrap(),
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
         );
 
         assert!(
-            !SpanContext::decode_w3c_traceparent(
+            !SpanContext::decode_traceparent(
                 "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00",
             )
             .unwrap()
-            .sampled
+            .is_sampled()
         );
         assert!(
-            SpanContext::decode_w3c_traceparent(
+            SpanContext::decode_traceparent(
                 "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
             )
             .unwrap()
-            .sampled
+            .is_sampled()
         );
         assert!(
-            !SpanContext::decode_w3c_traceparent(
+            !SpanContext::decode_traceparent(
                 "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-10",
             )
             .unwrap()
-            .sampled
+            .is_sampled()
         );
     }
 }

--- a/fastrace/src/lib.rs
+++ b/fastrace/src/lib.rs
@@ -105,9 +105,10 @@
 //! - A set of key-value properties
 //! - A reference to a parent `Span`
 //!
-//! A new `Span` can be started through [`Span::root()`], requiring the trace id and the
-//! parent span id from a remote source. If there's no remote parent span, the parent span
-//! id is typically set to its default value of zero.
+//! A new `Span` can be started through [`Span::root()`] with a [`SpanContext`]. Use
+//! [`SpanContext::random()`] for a new local root, or use
+//! [`SpanContext::decode_traceparent()`] to decode an incoming W3C traceparent value. A root with no
+//! remote parent is represented without a parent span id rather than with an all-zero `SpanId`.
 //!
 //! Once we have the root `Span`, we can create a child `Span` using [`Span::enter_with_parent()`],
 //! thereby establishing the reference relationship between the spans.
@@ -395,9 +396,11 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use crate::collector::SpanRecord;
     #[doc(no_inline)]
+    pub use crate::collector::TraceFlags;
+    #[doc(no_inline)]
     pub use crate::collector::TraceId;
     #[doc(no_inline)]
-    pub use crate::collector::W3CTraceContext;
+    pub use crate::collector::TraceState;
     #[doc(no_inline)]
     pub use crate::event::Event;
     #[doc(no_inline)]

--- a/fastrace/src/lib.rs
+++ b/fastrace/src/lib.rs
@@ -105,10 +105,11 @@
 //! - A set of key-value properties
 //! - A reference to a parent `Span`
 //!
-//! A new `Span` can be started through [`Span::root()`] with a [`SpanContext`]. Use
-//! [`SpanContext::random()`] for a new local root, or use
-//! [`SpanContext::decode_traceparent()`] to decode an incoming W3C traceparent value. A root with no
-//! remote parent is represented without a parent span id rather than with an all-zero `SpanId`.
+//! A new `Span` can be started through [`Span::root()`] with a [`collector::SpanContext`]. Use
+//! [`collector::SpanContext::random()`] for a new local root, or use
+//! [`collector::SpanContext::decode_traceparent()`] to decode an incoming W3C traceparent value. A
+//! root with no remote parent is represented without a parent span id rather than with an all-zero
+//! `SpanId`.
 //!
 //! Once we have the root `Span`, we can create a child `Span` using [`Span::enter_with_parent()`],
 //! thereby establishing the reference relationship between the spans.

--- a/fastrace/src/local/local_collector.rs
+++ b/fastrace/src/local/local_collector.rs
@@ -248,7 +248,7 @@ mod tests {
 
     fn token(trace: u128, collect_id: usize) -> CollectToken {
         CollectToken {
-            trace_id: TraceId::from_bytes(trace.to_be_bytes()).unwrap(),
+            trace_id: TraceId::from_bytes(trace.to_be_bytes()),
             parent_id: None,
             trace_flags: TraceFlags::SAMPLED,
             trace_state: TraceState::EMPTY,

--- a/fastrace/src/local/local_collector.rs
+++ b/fastrace/src/local/local_collector.rs
@@ -248,7 +248,7 @@ mod tests {
 
     fn token(trace: u128, collect_id: usize) -> CollectToken {
         CollectToken {
-            trace_id: TraceId::from_bytes(trace.to_be_bytes()),
+            trace_id: TraceId::from_bytes(trace.to_be_bytes()).unwrap(),
             parent_id: None,
             trace_flags: TraceFlags::SAMPLED,
             trace_state: TraceState::EMPTY,

--- a/fastrace/src/local/local_collector.rs
+++ b/fastrace/src/local/local_collector.rs
@@ -239,11 +239,24 @@ impl LocalSpans {
 mod tests {
     use super::*;
     use crate::collector::CollectToken;
-    use crate::collector::SpanId;
+    use crate::collector::TraceFlags;
+    use crate::collector::TraceState;
     use crate::prelude::LocalSpan;
     use crate::prelude::TraceId;
     use crate::util::tree::tree_str_from_raw_spans;
     use crate::util::tree::tree_str_from_span_records;
+
+    fn token(trace: u128, collect_id: usize) -> CollectToken {
+        CollectToken {
+            trace_id: TraceId::from_bytes(trace.to_be_bytes()).unwrap(),
+            parent_id: None,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+            collect_id,
+            is_root: false,
+            is_sampled: true,
+        }
+    }
 
     #[test]
     fn local_collector_basic() {
@@ -252,14 +265,8 @@ mod tests {
 
         let span1 = stack.borrow_mut().enter_span("span1").unwrap();
         {
-            let token2 = CollectToken {
-                trace_id: TraceId(1234),
-                parent_id: SpanId::default(),
-                collect_id: 42,
-                is_root: false,
-                is_sampled: true,
-            };
-            let collector2 = LocalCollector::new(Some(token2), stack.clone());
+            let token2 = token(1234, 42);
+            let collector2 = LocalCollector::new(Some(token2.clone()), stack.clone());
             let span2 = stack.borrow_mut().enter_span("span2").unwrap();
             let span3 = stack.borrow_mut().enter_span("span3").unwrap();
             stack.borrow_mut().exit_span(span3);
@@ -292,13 +299,7 @@ span1 []
 
         let span1 = stack.borrow_mut().enter_span("span1").unwrap();
         {
-            let token2 = CollectToken {
-                trace_id: TraceId(1234),
-                parent_id: SpanId::default(),
-                collect_id: 42,
-                is_root: false,
-                is_sampled: true,
-            };
+            let token2 = token(1234, 42);
             let collector2 = LocalCollector::new(Some(token2), stack.clone());
             let span2 = stack.borrow_mut().enter_span("span2").unwrap();
             let span3 = stack.borrow_mut().enter_span("span3").unwrap();

--- a/fastrace/src/local/local_span.rs
+++ b/fastrace/src/local/local_span.rs
@@ -96,10 +96,7 @@ impl LocalSpan {
     /// use fastrace::prelude::*;
     ///
     /// let root = Span::root("root", SpanContext::random());
-    /// let link = SpanContext::new(
-    ///     TraceId::from_hex("1").unwrap(),
-    ///     SpanId::from_hex("2").unwrap(),
-    /// );
+    /// let link = SpanContext::random();
     /// let _g = root.set_local_parent();
     ///
     /// let _span = LocalSpan::enter_with_local_parent("child").with_link(link);
@@ -173,10 +170,7 @@ impl LocalSpan {
     /// use fastrace::prelude::*;
     ///
     /// let root = Span::root("root", SpanContext::random());
-    /// let link = SpanContext::new(
-    ///     TraceId::from_hex("1").unwrap(),
-    ///     SpanId::from_hex("2").unwrap(),
-    /// );
+    /// let link = SpanContext::random();
     /// let _g = root.set_local_parent();
     ///
     /// let _span = LocalSpan::enter_with_local_parent("child");

--- a/fastrace/src/local/local_span.rs
+++ b/fastrace/src/local/local_span.rs
@@ -288,7 +288,7 @@ mod tests {
 
     fn token(trace: u128, collect_id: usize) -> CollectToken {
         CollectToken {
-            trace_id: TraceId::from_bytes(trace.to_be_bytes()).unwrap(),
+            trace_id: TraceId::from_bytes(trace.to_be_bytes()),
             parent_id: None,
             trace_flags: TraceFlags::SAMPLED,
             trace_state: TraceState::EMPTY,

--- a/fastrace/src/local/local_span.rs
+++ b/fastrace/src/local/local_span.rs
@@ -282,7 +282,7 @@ mod tests {
 
     fn token(trace: u128, collect_id: usize) -> CollectToken {
         CollectToken {
-            trace_id: TraceId::from_bytes(trace.to_be_bytes()),
+            trace_id: TraceId::from_bytes(trace.to_be_bytes()).unwrap(),
             parent_id: None,
             trace_flags: TraceFlags::SAMPLED,
             trace_state: TraceState::EMPTY,

--- a/fastrace/src/local/local_span.rs
+++ b/fastrace/src/local/local_span.rs
@@ -96,7 +96,10 @@ impl LocalSpan {
     /// use fastrace::prelude::*;
     ///
     /// let root = Span::root("root", SpanContext::random());
-    /// let link = SpanContext::new(TraceId(1), SpanId(2));
+    /// let link = SpanContext::new(
+    ///     TraceId::from_hex("1").unwrap(),
+    ///     SpanId::from_hex("2").unwrap(),
+    /// );
     /// let _g = root.set_local_parent();
     ///
     /// let _span = LocalSpan::enter_with_local_parent("child").with_link(link);
@@ -170,7 +173,10 @@ impl LocalSpan {
     /// use fastrace::prelude::*;
     ///
     /// let root = Span::root("root", SpanContext::random());
-    /// let link = SpanContext::new(TraceId(1), SpanId(2));
+    /// let link = SpanContext::new(
+    ///     TraceId::from_hex("1").unwrap(),
+    ///     SpanId::from_hex("2").unwrap(),
+    /// );
     /// let _g = root.set_local_parent();
     ///
     /// let _span = LocalSpan::enter_with_local_parent("child");
@@ -274,23 +280,30 @@ impl Drop for LocalSpan {
 mod tests {
     use super::*;
     use crate::collector::CollectToken;
-    use crate::collector::SpanId;
+    use crate::collector::TraceFlags;
+    use crate::collector::TraceState;
     use crate::local::LocalCollector;
     use crate::prelude::TraceId;
     use crate::util::tree::tree_str_from_raw_spans;
+
+    fn token(trace: u128, collect_id: usize) -> CollectToken {
+        CollectToken {
+            trace_id: TraceId::from_bytes(trace.to_be_bytes()).unwrap(),
+            parent_id: None,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+            collect_id,
+            is_root: false,
+            is_sampled: true,
+        }
+    }
 
     #[test]
     fn local_span_basic() {
         let stack = Rc::new(RefCell::new(LocalSpanStack::with_capacity(16)));
 
-        let token = CollectToken {
-            trace_id: TraceId(1234),
-            parent_id: SpanId::default(),
-            collect_id: 42,
-            is_root: false,
-            is_sampled: true,
-        };
-        let collector = LocalCollector::new(Some(token), stack.clone());
+        let token = token(1234, 42);
+        let collector = LocalCollector::new(Some(token.clone()), stack.clone());
 
         {
             let _g = LocalSpan::enter_with_stack("span1", stack.clone());
@@ -321,13 +334,7 @@ span1 []
     fn drop_out_of_order() {
         let stack = Rc::new(RefCell::new(LocalSpanStack::with_capacity(16)));
 
-        let token = CollectToken {
-            trace_id: TraceId(1234),
-            parent_id: SpanId::default(),
-            collect_id: 42,
-            is_root: false,
-            is_sampled: true,
-        };
+        let token = token(1234, 42);
         let collector = LocalCollector::new(Some(token), stack.clone());
 
         {

--- a/fastrace/src/local/local_span_line.rs
+++ b/fastrace/src/local/local_span_line.rs
@@ -156,7 +156,7 @@ mod tests {
     use crate::util::tree::tree_str_from_raw_spans;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+        TraceId::from_bytes(value.to_be_bytes())
     }
 
     fn token(trace: u128, parent_id: Option<SpanId>, collect_id: usize) -> CollectToken {

--- a/fastrace/src/local/local_span_line.rs
+++ b/fastrace/src/local/local_span_line.rs
@@ -125,10 +125,9 @@ impl SpanLine {
     pub fn current_collect_token(&self) -> Option<CollectToken> {
         self.collect_token.as_ref().map(|item| CollectToken {
             trace_id: item.trace_id,
-            parent_id: self
-                .span_queue
-                .current_parent_id()
-                .unwrap_or(item.parent_id),
+            parent_id: self.span_queue.current_parent_id().or(item.parent_id),
+            trace_flags: item.trace_flags,
+            trace_state: item.trace_state.clone(),
             collect_id: item.collect_id,
             is_root: item.is_root,
             is_sampled: item.is_sampled,
@@ -151,8 +150,26 @@ pub struct LocalSpanHandle {
 mod tests {
     use super::*;
     use crate::collector::SpanId;
+    use crate::collector::TraceFlags;
+    use crate::collector::TraceState;
     use crate::prelude::TraceId;
     use crate::util::tree::tree_str_from_raw_spans;
+
+    fn trace_id(value: u128) -> TraceId {
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+    }
+
+    fn token(trace: u128, parent_id: Option<SpanId>, collect_id: usize) -> CollectToken {
+        CollectToken {
+            trace_id: trace_id(trace),
+            parent_id,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+            collect_id,
+            is_root: false,
+            is_sampled: true,
+        }
+    }
 
     #[test]
     fn span_line_basic() {
@@ -184,27 +201,18 @@ span1 []
 
     #[test]
     fn current_collect_token() {
-        let token = CollectToken {
-            trace_id: TraceId(1234),
-            parent_id: SpanId::default(),
-            collect_id: 42,
-            is_root: false,
-            is_sampled: true,
-        };
-        let mut span_line = SpanLine::new(16, 1, Some(token));
+        let token = token(1234, None, 42);
+        let mut span_line = SpanLine::new(16, 1, Some(token.clone()));
 
         let current_token = span_line.current_collect_token().unwrap();
         assert_eq!(current_token, token);
 
         let span = span_line.start_span("span").unwrap();
         let current_token = span_line.current_collect_token().unwrap();
-        assert_eq!(current_token, CollectToken {
-            trace_id: TraceId(1234),
-            parent_id: span_line.span_queue.current_parent_id().unwrap(),
-            collect_id: 42,
-            is_root: false,
-            is_sampled: true,
-        });
+        assert_eq!(
+            current_token,
+            self::token(1234, span_line.span_queue.current_parent_id(), 42)
+        );
         span_line.finish_span(span);
 
         let current_token = span_line.current_collect_token().unwrap();
@@ -241,14 +249,8 @@ span []
 
     #[test]
     fn unmatched_epoch_finish_span() {
-        let item = CollectToken {
-            trace_id: TraceId(1234),
-            parent_id: SpanId::default(),
-            collect_id: 42,
-            is_root: false,
-            is_sampled: true,
-        };
-        let mut span_line1 = SpanLine::new(16, 1, Some(item));
+        let item = token(1234, None, 42);
+        let mut span_line1 = SpanLine::new(16, 1, Some(item.clone()));
         let mut span_line2 = SpanLine::new(16, 2, None);
         assert_eq!(span_line1.span_line_epoch(), 1);
         assert_eq!(span_line2.span_line_epoch(), 2);

--- a/fastrace/src/local/local_span_line.rs
+++ b/fastrace/src/local/local_span_line.rs
@@ -156,7 +156,7 @@ mod tests {
     use crate::util::tree::tree_str_from_raw_spans;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes())
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
     }
 
     fn token(trace: u128, parent_id: Option<SpanId>, collect_id: usize) -> CollectToken {

--- a/fastrace/src/local/local_span_stack.rs
+++ b/fastrace/src/local/local_span_stack.rs
@@ -174,11 +174,11 @@ mod tests {
     use crate::util::tree::tree_str_from_raw_spans;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+        TraceId::from_bytes(value.to_be_bytes())
     }
 
     fn span_id(value: u64) -> SpanId {
-        SpanId::from_bytes(value.to_be_bytes()).unwrap()
+        SpanId::from_bytes(value.to_be_bytes())
     }
 
     fn token(trace: u128, parent: Option<u64>, collect_id: usize) -> CollectToken {

--- a/fastrace/src/local/local_span_stack.rs
+++ b/fastrace/src/local/local_span_stack.rs
@@ -168,21 +168,37 @@ mod tests {
     use super::*;
     use crate::collector::CollectToken;
     use crate::collector::SpanId;
+    use crate::collector::TraceFlags;
+    use crate::collector::TraceState;
     use crate::prelude::TraceId;
     use crate::util::tree::tree_str_from_raw_spans;
+
+    fn trace_id(value: u128) -> TraceId {
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+    }
+
+    fn span_id(value: u64) -> SpanId {
+        SpanId::from_bytes(value.to_be_bytes()).unwrap()
+    }
+
+    fn token(trace: u128, parent: Option<u64>, collect_id: usize) -> CollectToken {
+        CollectToken {
+            trace_id: trace_id(trace),
+            parent_id: parent.map(span_id),
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+            collect_id,
+            is_root: false,
+            is_sampled: true,
+        }
+    }
 
     #[test]
     fn span_stack_basic() {
         let mut span_stack = LocalSpanStack::with_capacity(16);
 
-        let token1 = CollectToken {
-            trace_id: TraceId(1234),
-            parent_id: SpanId::default(),
-            collect_id: 42,
-            is_root: false,
-            is_sampled: true,
-        };
-        let span_line1 = span_stack.register_span_line(Some(token1)).unwrap();
+        let token1 = token(1234, None, 42);
+        let span_line1 = span_stack.register_span_line(Some(token1.clone())).unwrap();
         {
             {
                 let span1 = span_stack.enter_span("span1").unwrap();
@@ -193,14 +209,8 @@ mod tests {
                 span_stack.exit_span(span1);
             }
 
-            let token2 = CollectToken {
-                trace_id: TraceId(1235),
-                parent_id: SpanId::default(),
-                collect_id: 48,
-                is_root: false,
-                is_sampled: true,
-            };
-            let span_line2 = span_stack.register_span_line(Some(token2)).unwrap();
+            let token2 = token(1235, None, 48);
+            let span_line2 = span_stack.register_span_line(Some(token2.clone())).unwrap();
             {
                 let span3 = span_stack.enter_span("span3").unwrap();
                 {
@@ -241,26 +251,14 @@ span1 []
             let span_line2 = span_stack.register_span_line(None).unwrap();
             {
                 let span_line3 = span_stack
-                    .register_span_line(Some(CollectToken {
-                        trace_id: TraceId(1234),
-                        parent_id: SpanId::default(),
-                        collect_id: 42,
-                        is_root: false,
-                        is_sampled: true,
-                    }))
+                    .register_span_line(Some(token(1234, None, 42)))
                     .unwrap();
                 {
                     let span_line4 = span_stack.register_span_line(None).unwrap();
                     {
                         assert!(
                             span_stack
-                                .register_span_line(Some(CollectToken {
-                                    trace_id: TraceId(1235),
-                                    parent_id: SpanId::default(),
-                                    collect_id: 43,
-                                    is_root: false,
-                                    is_sampled: true,
-                                }))
+                                .register_span_line(Some(token(1235, None, 43)))
                                 .is_none()
                         );
                         assert!(span_stack.register_span_line(None).is_none());
@@ -272,13 +270,7 @@ span1 []
                     {
                         assert!(
                             span_stack
-                                .register_span_line(Some(CollectToken {
-                                    trace_id: TraceId(1236),
-                                    parent_id: SpanId::default(),
-                                    collect_id: 44,
-                                    is_root: false,
-                                    is_sampled: true,
-                                }))
+                                .register_span_line(Some(token(1236, None, 44)))
                                 .is_none()
                         );
                         assert!(span_stack.register_span_line(None).is_none());
@@ -296,41 +288,23 @@ span1 []
     fn current_collect_token() {
         let mut span_stack = LocalSpanStack::with_capacity(16);
         assert!(span_stack.current_collect_token().is_none());
-        let token1 = CollectToken {
-            trace_id: TraceId(1),
-            parent_id: SpanId(1),
-            collect_id: 1,
-            is_root: false,
-            is_sampled: true,
-        };
-        let span_line1 = span_stack.register_span_line(Some(token1)).unwrap();
+        let token1 = token(1, Some(1), 1);
+        let span_line1 = span_stack.register_span_line(Some(token1.clone())).unwrap();
         assert_eq!(span_stack.current_collect_token().unwrap(), token1);
         {
             let span_line2 = span_stack.register_span_line(None).unwrap();
             assert!(span_stack.current_collect_token().is_none());
             {
-                let token3 = CollectToken {
-                    trace_id: TraceId(3),
-                    parent_id: SpanId(3),
-                    collect_id: 3,
-                    is_root: false,
-                    is_sampled: true,
-                };
-                let span_line3 = span_stack.register_span_line(Some(token3)).unwrap();
+                let token3 = token(3, Some(3), 3);
+                let span_line3 = span_stack.register_span_line(Some(token3.clone())).unwrap();
                 assert_eq!(span_stack.current_collect_token().unwrap(), token3);
                 let _ = span_stack.unregister_and_collect(span_line3).unwrap();
             }
             assert!(span_stack.current_collect_token().is_none());
             let _ = span_stack.unregister_and_collect(span_line2).unwrap();
 
-            let token4 = CollectToken {
-                trace_id: TraceId(4),
-                parent_id: SpanId(4),
-                collect_id: 4,
-                is_root: false,
-                is_sampled: true,
-            };
-            let span_line4 = span_stack.register_span_line(Some(token4)).unwrap();
+            let token4 = token(4, Some(4), 4);
+            let span_line4 = span_stack.register_span_line(Some(token4.clone())).unwrap();
             assert_eq!(span_stack.current_collect_token().unwrap(), token4);
             let _ = span_stack.unregister_and_collect(span_line4).unwrap();
         }
@@ -347,13 +321,7 @@ span1 []
         let span1 = span_stack.enter_span("span1").unwrap();
         {
             let span_line2 = span_stack
-                .register_span_line(Some(CollectToken {
-                    trace_id: TraceId(1234),
-                    parent_id: SpanId::default(),
-                    collect_id: 42,
-                    is_root: false,
-                    is_sampled: true,
-                }))
+                .register_span_line(Some(token(1234, None, 42)))
                 .unwrap();
             span_stack.exit_span(span1);
             let _ = span_stack.unregister_and_collect(span_line2).unwrap();
@@ -369,13 +337,7 @@ span1 []
         let span1 = span_stack.enter_span("span1").unwrap();
         {
             let span_line2 = span_stack
-                .register_span_line(Some(CollectToken {
-                    trace_id: TraceId(1234),
-                    parent_id: SpanId::default(),
-                    collect_id: 42,
-                    is_root: false,
-                    is_sampled: true,
-                }))
+                .register_span_line(Some(token(1234, None, 42)))
                 .unwrap();
             span_stack.with_properties(&span1, || [("k1", "v1")]);
             let _ = span_stack.unregister_and_collect(span_line2).unwrap();
@@ -391,13 +353,7 @@ span1 []
         let span_line1 = span_stack.register_span_line(None).unwrap();
         {
             let span_line2 = span_stack
-                .register_span_line(Some(CollectToken {
-                    trace_id: TraceId(1234),
-                    parent_id: SpanId::default(),
-                    collect_id: 42,
-                    is_root: false,
-                    is_sampled: true,
-                }))
+                .register_span_line(Some(token(1234, None, 42)))
                 .unwrap();
             let _ = span_stack.unregister_and_collect(span_line1).unwrap();
             let _ = span_stack.unregister_and_collect(span_line2).unwrap();

--- a/fastrace/src/local/local_span_stack.rs
+++ b/fastrace/src/local/local_span_stack.rs
@@ -174,11 +174,11 @@ mod tests {
     use crate::util::tree::tree_str_from_raw_spans;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes())
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
     }
 
     fn span_id(value: u64) -> SpanId {
-        SpanId::from_bytes(value.to_be_bytes())
+        SpanId::from_bytes(value.to_be_bytes()).unwrap()
     }
 
     fn token(trace: u128, parent: Option<u64>, collect_id: usize) -> CollectToken {

--- a/fastrace/src/span.rs
+++ b/fastrace/src/span.rs
@@ -751,6 +751,15 @@ mod tests {
         TraceId::from_bytes(value.to_be_bytes()).unwrap()
     }
 
+    fn root_context(value: u128) -> SpanContext {
+        SpanContext {
+            trace_id: trace_id(value),
+            span_id: None,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+        }
+    }
+
     #[test]
     fn noop_basic() {
         let span = Span::noop();
@@ -764,7 +773,7 @@ mod tests {
         crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
 
         let routine = || {
-            let _root = Span::root("root", SpanContext::root(trace_id(12)));
+            let _root = Span::root("root", root_context(12));
 
             fastrace::flush();
         };

--- a/fastrace/src/span.rs
+++ b/fastrace/src/span.rs
@@ -748,7 +748,7 @@ mod tests {
     use crate::util::tree::tree_str_from_span_sets;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+        TraceId::from_bytes(value.to_be_bytes())
     }
 
     #[test]

--- a/fastrace/src/span.rs
+++ b/fastrace/src/span.rs
@@ -85,7 +85,8 @@ impl Span {
 
         #[cfg(feature = "enable")]
         {
-            let collect_id = if parent.sampled {
+            let is_sampled = parent.is_sampled();
+            let collect_id = if is_sampled {
                 current_collect().start_collect()
             } else {
                 NOT_SAMPLED_COLLECT_ID
@@ -94,9 +95,11 @@ impl Span {
             let token = CollectToken {
                 trace_id: parent.trace_id,
                 parent_id: parent.span_id,
+                trace_flags: parent.trace_flags,
+                trace_state: parent.trace_state,
                 collect_id,
                 is_root: true,
-                is_sampled: parent.sampled,
+                is_sampled,
             };
 
             Self::new(token, name, Some(collect_id))
@@ -623,7 +626,9 @@ impl SpanInner {
     pub(crate) fn issue_collect_token(&self) -> CollectToken {
         CollectToken {
             trace_id: self.collect_token.trace_id,
-            parent_id: self.raw_span.id,
+            parent_id: Some(self.raw_span.id),
+            trace_flags: self.collect_token.trace_flags,
+            trace_state: self.collect_token.trace_state.clone(),
             collect_id: self.collect_token.collect_id,
             is_root: false,
             is_sampled: self.collect_token.is_sampled,
@@ -736,9 +741,15 @@ mod tests {
     use super::*;
     use crate::collector::ConsoleReporter;
     use crate::collector::MockGlobalCollect;
+    use crate::collector::TraceFlags;
+    use crate::collector::TraceState;
     use crate::local::LocalSpan;
     use crate::prelude::TraceId;
     use crate::util::tree::tree_str_from_span_sets;
+
+    fn trace_id(value: u128) -> TraceId {
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
+    }
 
     #[test]
     fn noop_basic() {
@@ -753,7 +764,7 @@ mod tests {
         crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
 
         let routine = || {
-            let _root = Span::root("root", SpanContext::new(TraceId(12), SpanId::default()));
+            let _root = Span::root("root", SpanContext::root(trace_id(12)));
 
             fastrace::flush();
         };
@@ -770,8 +781,10 @@ mod tests {
             .with(
                 predicate::always(),
                 predicate::eq::<CollectToken>(CollectToken {
-                    trace_id: TraceId(12),
-                    parent_id: SpanId::default(),
+                    trace_id: trace_id(12),
+                    parent_id: None,
+                    trace_flags: TraceFlags::SAMPLED,
+                    trace_state: TraceState::EMPTY,
                     collect_id: 42,
                     is_root: true,
                     is_sampled: true,
@@ -912,10 +925,10 @@ root []
 
         let routine = || {
             let parent_ctx = SpanContext::random();
-            let parent1 = Span::root("parent1", parent_ctx);
-            let parent2 = Span::root("parent2", parent_ctx);
-            let parent3 = Span::root("parent3", parent_ctx);
-            let parent4 = Span::root("parent4", parent_ctx);
+            let parent1 = Span::root("parent1", parent_ctx.clone());
+            let parent2 = Span::root("parent2", parent_ctx.clone());
+            let parent3 = Span::root("parent3", parent_ctx.clone());
+            let parent4 = Span::root("parent4", parent_ctx.clone());
             let parent5 = Span::root("parent5", parent_ctx);
 
             let stack = Rc::new(RefCell::new(LocalSpanStack::with_capacity(16)));

--- a/fastrace/src/span.rs
+++ b/fastrace/src/span.rs
@@ -85,7 +85,7 @@ impl Span {
 
         #[cfg(feature = "enable")]
         {
-            let is_sampled = parent.is_sampled();
+            let is_sampled = parent.trace_flags.is_sampled();
             let collect_id = if is_sampled {
                 current_collect().start_collect()
             } else {

--- a/fastrace/src/span.rs
+++ b/fastrace/src/span.rs
@@ -748,7 +748,7 @@ mod tests {
     use crate::util::tree::tree_str_from_span_sets;
 
     fn trace_id(value: u128) -> TraceId {
-        TraceId::from_bytes(value.to_be_bytes())
+        TraceId::from_bytes(value.to_be_bytes()).unwrap()
     }
 
     #[test]

--- a/fastrace/src/util/tree.rs
+++ b/fastrace/src/util/tree.rs
@@ -116,7 +116,7 @@ impl Tree {
             collect
                 .entry(token.collect_id)
                 .or_default()
-                .insert(Some(SpanId(0)), ("".into(), vec![], vec![], vec![]));
+                .insert(None, ("".into(), vec![], vec![], vec![]));
             match span_set {
                 SpanSet::Span(span) => {
                     collect.entry(token.collect_id).or_default().insert(
@@ -170,12 +170,12 @@ impl Tree {
         for (span_set, token) in span_sets {
             match span_set {
                 SpanSet::Span(span) => {
-                    let parent_id = span.parent_id.unwrap_or(token.parent_id);
+                    let parent_id = span.parent_id.or(token.parent_id);
                     collect
                         .get_mut(&token.collect_id)
                         .as_mut()
                         .unwrap()
-                        .get_mut(&Some(parent_id))
+                        .get_mut(&parent_id)
                         .as_mut()
                         .unwrap()
                         .1
@@ -183,12 +183,12 @@ impl Tree {
                 }
                 SpanSet::LocalSpansInner(spans) => {
                     for span in spans.spans.iter() {
-                        let parent_id = span.parent_id.unwrap_or(token.parent_id);
+                        let parent_id = span.parent_id.or(token.parent_id);
                         collect
                             .get_mut(&token.collect_id)
                             .as_mut()
                             .unwrap()
-                            .get_mut(&Some(parent_id))
+                            .get_mut(&parent_id)
                             .as_mut()
                             .unwrap()
                             .1
@@ -197,12 +197,12 @@ impl Tree {
                 }
                 SpanSet::SharedLocalSpans(spans) => {
                     for span in spans.spans.iter() {
-                        let parent_id = span.parent_id.unwrap_or(token.parent_id);
+                        let parent_id = span.parent_id.or(token.parent_id);
                         collect
                             .get_mut(&token.collect_id)
                             .as_mut()
                             .unwrap()
-                            .get_mut(&Some(parent_id))
+                            .get_mut(&parent_id)
                             .as_mut()
                             .unwrap()
                             .1
@@ -215,7 +215,7 @@ impl Tree {
         let mut res = collect
             .into_iter()
             .map(|(id, mut children)| {
-                let mut tree = Self::build_tree(Some(SpanId(0)), &mut children);
+                let mut tree = Self::build_tree(None, &mut children);
                 tree.sort();
                 assert_eq!(tree.children.len(), 1);
                 (id, tree.children.pop().unwrap())
@@ -228,7 +228,7 @@ impl Tree {
     pub fn from_span_records(span_records: Vec<SpanRecord>) -> Tree {
         let mut children: TreeChildren = HashMap::new();
 
-        children.insert(Some(SpanId(0)), ("".into(), vec![], vec![], vec![]));
+        children.insert(None, ("".into(), vec![], vec![], vec![]));
         for span in &span_records {
             children.insert(
                 Some(span.span_id),
@@ -256,14 +256,14 @@ impl Tree {
         }
         for span in &span_records {
             children
-                .get_mut(&Some(span.parent_id))
+                .get_mut(&span.parent_id)
                 .as_mut()
                 .unwrap()
                 .1
                 .push(span.span_id);
         }
 
-        let mut t = Self::build_tree(Some(SpanId(0)), &mut children);
+        let mut t = Self::build_tree(None, &mut children);
         t.sort();
         assert_eq!(t.children.len(), 1);
         t.children.remove(0)

--- a/fastrace/tests/lib.rs
+++ b/fastrace/tests/lib.rs
@@ -11,6 +11,14 @@ use fastrace::util::tree::tree_str_from_span_records;
 use serial_test::serial;
 use tokio::runtime::Builder;
 
+fn trace_id(value: u128) -> TraceId {
+    TraceId::from_bytes(value.to_be_bytes()).unwrap()
+}
+
+fn span_id(value: u64) -> SpanId {
+    SpanId::from_bytes(value.to_be_bytes()).unwrap()
+}
+
 fn four_spans() {
     {
         // wide
@@ -66,12 +74,12 @@ fn span_links() {
     let (reporter, collected_spans) = TestReporter::new();
     fastrace::set_reporter(reporter, Config::default());
 
-    let root1 = Span::root("root1", SpanContext::new(TraceId(1), SpanId(0)));
-    let root2 = Span::root("root2", SpanContext::new(TraceId(2), SpanId(0)));
+    let root1 = Span::root("root1", SpanContext::root(trace_id(1)));
+    let root2 = Span::root("root2", SpanContext::root(trace_id(2)));
     let link = SpanContext::from_span(&root2).unwrap();
 
-    let child = Span::enter_with_parent("child", &root1).with_link(link);
-    child.add_link(link);
+    let child = Span::enter_with_parent("child", &root1).with_link(link.clone());
+    child.add_link(link.clone());
 
     drop(child);
     drop(root1);
@@ -81,7 +89,7 @@ fn span_links() {
 
     let spans = collected_spans.lock();
     let child_record = spans.iter().find(|span| span.name == "child").unwrap();
-    assert_eq!(child_record.links, vec![link, link]);
+    assert_eq!(child_record.links, vec![link.clone(), link]);
 }
 
 #[test]
@@ -90,14 +98,14 @@ fn local_span_links() {
     let (reporter, collected_spans) = TestReporter::new();
     fastrace::set_reporter(reporter, Config::default());
 
-    let root = Span::root("root", SpanContext::new(TraceId(1), SpanId(0)));
-    let link1 = SpanContext::new(TraceId(2), SpanId(1));
-    let link2 = SpanContext::new(TraceId(3), SpanId(2));
+    let root = Span::root("root", SpanContext::root(trace_id(1)));
+    let link1 = SpanContext::new(trace_id(2), span_id(1));
+    let link2 = SpanContext::new(trace_id(3), span_id(2));
 
     {
         let _g = root.set_local_parent();
-        let _span = LocalSpan::enter_with_local_parent("local").with_link(link1);
-        LocalSpan::add_link(link2);
+        let _span = LocalSpan::enter_with_local_parent("local").with_link(link1.clone());
+        LocalSpan::add_link(link2.clone());
     }
 
     drop(root);
@@ -115,9 +123,9 @@ fn single_thread_multiple_spans() {
     fastrace::set_reporter(reporter, Config::default());
 
     {
-        let root1 = Span::root("root1", SpanContext::new(TraceId(12), SpanId(0)));
-        let root2 = Span::root("root2", SpanContext::new(TraceId(13), SpanId(0)));
-        let root3 = Span::root("root3", SpanContext::new(TraceId(14), SpanId(0)));
+        let root1 = Span::root("root1", SpanContext::root(trace_id(12)));
+        let root2 = Span::root("root2", SpanContext::root(trace_id(13)));
+        let root3 = Span::root("root3", SpanContext::root(trace_id(14)));
 
         let local_collector = LocalCollector::start();
 
@@ -136,7 +144,7 @@ fn single_thread_multiple_spans() {
         collected_spans
             .lock()
             .iter()
-            .filter(|s| s.trace_id == TraceId(12))
+            .filter(|s| s.trace_id == trace_id(12))
             .cloned()
             .collect(),
     );
@@ -152,7 +160,7 @@ fn single_thread_multiple_spans() {
         collected_spans
             .lock()
             .iter()
-            .filter(|s| s.trace_id == TraceId(13))
+            .filter(|s| s.trace_id == trace_id(13))
             .cloned()
             .collect(),
     );
@@ -168,7 +176,7 @@ fn single_thread_multiple_spans() {
         collected_spans
             .lock()
             .iter()
-            .filter(|s| s.trace_id == TraceId(14))
+            .filter(|s| s.trace_id == trace_id(14))
             .cloned()
             .collect(),
     );
@@ -247,9 +255,9 @@ fn multiple_spans_without_local_spans() {
     fastrace::set_reporter(reporter, Config::default());
 
     {
-        let root1 = Span::root("root1", SpanContext::new(TraceId(12), SpanId::default()));
-        let root2 = Span::root("root2", SpanContext::new(TraceId(13), SpanId::default()));
-        let root3 = Span::root("root3", SpanContext::new(TraceId(14), SpanId::default()));
+        let root1 = Span::root("root1", SpanContext::root(trace_id(12)));
+        let root2 = Span::root("root2", SpanContext::root(trace_id(13)));
+        let root3 = Span::root("root3", SpanContext::root(trace_id(14)));
 
         let local_collector = LocalCollector::start();
 
@@ -267,7 +275,7 @@ fn multiple_spans_without_local_spans() {
         collected_spans
             .lock()
             .iter()
-            .filter(|s| s.trace_id == TraceId(12))
+            .filter(|s| s.trace_id == trace_id(12))
             .count(),
         1
     );
@@ -275,7 +283,7 @@ fn multiple_spans_without_local_spans() {
         collected_spans
             .lock()
             .iter()
-            .filter(|s| s.trace_id == TraceId(13))
+            .filter(|s| s.trace_id == trace_id(13))
             .count(),
         1
     );
@@ -283,7 +291,7 @@ fn multiple_spans_without_local_spans() {
         collected_spans
             .lock()
             .iter()
-            .filter(|s| s.trace_id == TraceId(14))
+            .filter(|s| s.trace_id == trace_id(14))
             .count(),
         0
     );

--- a/fastrace/tests/lib.rs
+++ b/fastrace/tests/lib.rs
@@ -12,11 +12,11 @@ use serial_test::serial;
 use tokio::runtime::Builder;
 
 fn trace_id(value: u128) -> TraceId {
-    TraceId::from_bytes(value.to_be_bytes())
+    TraceId::from_bytes(value.to_be_bytes()).unwrap()
 }
 
 fn span_id(value: u64) -> SpanId {
-    SpanId::from_bytes(value.to_be_bytes())
+    SpanId::from_bytes(value.to_be_bytes()).unwrap()
 }
 
 fn four_spans() {

--- a/fastrace/tests/lib.rs
+++ b/fastrace/tests/lib.rs
@@ -12,11 +12,11 @@ use serial_test::serial;
 use tokio::runtime::Builder;
 
 fn trace_id(value: u128) -> TraceId {
-    TraceId::from_bytes(value.to_be_bytes()).unwrap()
+    TraceId::from_bytes(value.to_be_bytes())
 }
 
 fn span_id(value: u64) -> SpanId {
-    SpanId::from_bytes(value.to_be_bytes()).unwrap()
+    SpanId::from_bytes(value.to_be_bytes())
 }
 
 fn four_spans() {

--- a/fastrace/tests/lib.rs
+++ b/fastrace/tests/lib.rs
@@ -19,6 +19,15 @@ fn span_id(value: u64) -> SpanId {
     SpanId::from_bytes(value.to_be_bytes()).unwrap()
 }
 
+fn root_context(value: u128) -> SpanContext {
+    SpanContext {
+        trace_id: trace_id(value),
+        span_id: None,
+        trace_flags: TraceFlags::SAMPLED,
+        trace_state: TraceState::EMPTY,
+    }
+}
+
 fn four_spans() {
     {
         // wide
@@ -74,8 +83,8 @@ fn span_links() {
     let (reporter, collected_spans) = TestReporter::new();
     fastrace::set_reporter(reporter, Config::default());
 
-    let root1 = Span::root("root1", SpanContext::root(trace_id(1)));
-    let root2 = Span::root("root2", SpanContext::root(trace_id(2)));
+    let root1 = Span::root("root1", root_context(1));
+    let root2 = Span::root("root2", root_context(2));
     let link = SpanContext::from_span(&root2).unwrap();
 
     let child = Span::enter_with_parent("child", &root1).with_link(link.clone());
@@ -98,7 +107,7 @@ fn local_span_links() {
     let (reporter, collected_spans) = TestReporter::new();
     fastrace::set_reporter(reporter, Config::default());
 
-    let root = Span::root("root", SpanContext::root(trace_id(1)));
+    let root = Span::root("root", root_context(1));
     let link1 = SpanContext::new(trace_id(2), span_id(1));
     let link2 = SpanContext::new(trace_id(3), span_id(2));
 
@@ -123,9 +132,9 @@ fn single_thread_multiple_spans() {
     fastrace::set_reporter(reporter, Config::default());
 
     {
-        let root1 = Span::root("root1", SpanContext::root(trace_id(12)));
-        let root2 = Span::root("root2", SpanContext::root(trace_id(13)));
-        let root3 = Span::root("root3", SpanContext::root(trace_id(14)));
+        let root1 = Span::root("root1", root_context(12));
+        let root2 = Span::root("root2", root_context(13));
+        let root3 = Span::root("root3", root_context(14));
 
         let local_collector = LocalCollector::start();
 
@@ -255,9 +264,9 @@ fn multiple_spans_without_local_spans() {
     fastrace::set_reporter(reporter, Config::default());
 
     {
-        let root1 = Span::root("root1", SpanContext::root(trace_id(12)));
-        let root2 = Span::root("root2", SpanContext::root(trace_id(13)));
-        let root3 = Span::root("root3", SpanContext::root(trace_id(14)));
+        let root1 = Span::root("root1", root_context(12));
+        let root2 = Span::root("root2", root_context(13));
+        let root3 = Span::root("root3", root_context(14));
 
         let local_collector = LocalCollector::start();
 

--- a/tests/statically-disable/src/main.rs
+++ b/tests/statically-disable/src/main.rs
@@ -34,8 +34,8 @@ fn main() {
     use fastrace::local::LocalCollector;
     use fastrace::prelude::*;
 
-    let trace_id = |value: u128| TraceId::from_bytes(value.to_be_bytes());
-    let span_id = |value: u64| SpanId::from_bytes(value.to_be_bytes());
+    let trace_id = |value: u128| TraceId::from_bytes(value.to_be_bytes()).unwrap();
+    let span_id = |value: u64| SpanId::from_bytes(value.to_be_bytes()).unwrap();
 
     fastrace::set_reporter(
         ConsoleReporter,

--- a/tests/statically-disable/src/main.rs
+++ b/tests/statically-disable/src/main.rs
@@ -34,15 +34,18 @@ fn main() {
     use fastrace::local::LocalCollector;
     use fastrace::prelude::*;
 
+    let trace_id = |value: u128| TraceId::from_bytes(value.to_be_bytes()).unwrap();
+    let span_id = |value: u64| SpanId::from_bytes(value.to_be_bytes()).unwrap();
+
     fastrace::set_reporter(
         ConsoleReporter,
         Config::default().report_interval(Duration::from_millis(10)),
     );
 
-    let root = Span::root("root", SpanContext::new(TraceId(0), SpanId(0)))
+    let root = Span::root("root", SpanContext::root(trace_id(1)))
         .with_property(|| ("k0", "v0"))
         .with_properties(|| [("k1", "v1")])
-        .with_link(SpanContext::new(TraceId(1), SpanId(1)));
+        .with_link(SpanContext::new(trace_id(2), span_id(1)));
 
     root.add_property(|| ("k1.5", "v1.5"));
     root.add_properties(|| [("k2", "v2")]);
@@ -51,7 +54,7 @@ fn main() {
             .with_property(|| ("k0", "v0"))
             .with_properties(|| [("k1", "v1")]),
     );
-    root.add_link(SpanContext::new(TraceId(1), SpanId(1)));
+    root.add_link(SpanContext::new(trace_id(2), span_id(1)));
 
     let _g = root.set_local_parent();
 
@@ -66,11 +69,11 @@ fn main() {
         .with_property(|| ("k1", "v1"))
         .with_properties(|| [("k", "v")]);
     let _span3 = LocalSpan::enter_with_local_parent("span3")
-        .with_link(SpanContext::new(TraceId(1), SpanId(1)));
+        .with_link(SpanContext::new(trace_id(2), span_id(1)));
 
     LocalSpan::add_property(|| ("k0", "v0"));
     LocalSpan::add_properties(|| [("k", "v")]);
-    LocalSpan::add_link(SpanContext::new(TraceId(1), SpanId(1)));
+    LocalSpan::add_link(SpanContext::new(trace_id(2), span_id(1)));
 
     let local_collector = LocalCollector::start();
     let _ = LocalSpan::enter_with_local_parent("span3");

--- a/tests/statically-disable/src/main.rs
+++ b/tests/statically-disable/src/main.rs
@@ -42,10 +42,18 @@ fn main() {
         Config::default().report_interval(Duration::from_millis(10)),
     );
 
-    let root = Span::root("root", SpanContext::root(trace_id(1)))
-        .with_property(|| ("k0", "v0"))
-        .with_properties(|| [("k1", "v1")])
-        .with_link(SpanContext::new(trace_id(2), span_id(1)));
+    let root = Span::root(
+        "root",
+        SpanContext {
+            trace_id: trace_id(1),
+            span_id: None,
+            trace_flags: TraceFlags::SAMPLED,
+            trace_state: TraceState::EMPTY,
+        },
+    )
+    .with_property(|| ("k0", "v0"))
+    .with_properties(|| [("k1", "v1")])
+    .with_link(SpanContext::new(trace_id(2), span_id(1)));
 
     root.add_property(|| ("k1.5", "v1.5"));
     root.add_properties(|| [("k2", "v2")]);

--- a/tests/statically-disable/src/main.rs
+++ b/tests/statically-disable/src/main.rs
@@ -34,8 +34,8 @@ fn main() {
     use fastrace::local::LocalCollector;
     use fastrace::prelude::*;
 
-    let trace_id = |value: u128| TraceId::from_bytes(value.to_be_bytes()).unwrap();
-    let span_id = |value: u64| SpanId::from_bytes(value.to_be_bytes()).unwrap();
+    let trace_id = |value: u128| TraceId::from_bytes(value.to_be_bytes());
+    let span_id = |value: u64| SpanId::from_bytes(value.to_be_bytes());
 
     fastrace::set_reporter(
         ConsoleReporter,


### PR DESCRIPTION
## Summary

- Replace public tuple-style trace and span IDs with opaque ID APIs and explicit `INVALID` values
- Collapse W3C propagation onto `SpanContext` with `TraceFlags`, `TraceState`, `traceparent` encode/decode, and header-name constants
- Preserve root spans without remote parents through `Option<SpanId>` internally instead of a public zero-span sentinel
- Update OpenTelemetry, Datadog, and Jaeger mappings to consume the new byte-oriented ID APIs
- Refresh docs, examples, benches, no-feature coverage, and propagation tests for the new 0.8 breaking contract

## Design Notes

`TraceId` and `SpanId` are no longer public numeric tuple wrappers. Public construction goes through `from_bytes`, `from_hex`, or `FromStr`. All-zero IDs are represented as `TraceId::INVALID` and `SpanId::INVALID`; W3C `traceparent` parse and encode reject those invalid IDs at the propagation boundary.

`SpanContext` is now the single cheap propagation and parent/link context. It carries trace flags and tracestate directly, and `Span` remains the live timed object responsible for collection and reporting.
