### PR TITLE
chore: release fastrace-opentelemetry v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "fastrace-opentelemetry"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "fastrace 0.7.17",
  "log",

--- a/fastrace-opentelemetry/CHANGELOG.md
+++ b/fastrace-opentelemetry/CHANGELOG.md
@@ -4,6 +4,8 @@ All significant changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.18.0
+
 ### Improvements
 
 * Upgraded `opentelemetry` to 0.32.0.

--- a/fastrace-opentelemetry/Cargo.toml
+++ b/fastrace-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastrace-opentelemetry"
-version = "0.17.0"
+version = "0.18.0"
 
 categories = ["development-tools::debugging"]
 description = "Opentelemetry reporter for fastrace"

--- a/fastrace-opentelemetry/README.md
+++ b/fastrace-opentelemetry/README.md
@@ -11,7 +11,7 @@
 ```toml
 [dependencies]
 fastrace = { version = "0.7", features = ["enable"] }
-fastrace-opentelemetry = "0.15"
+fastrace-opentelemetry = "0.18"
 ```
 
 ## Setup OpenTelemetry Collector


### PR DESCRIPTION
## Summary

Prepare `fastrace-opentelemetry` v0.18.0 for release.

This release includes the OpenTelemetry 0.32.0 dependency upgrade and refreshes the README dependency example.