### PR TITLE
chore: upgrade syn to 3.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -44,7 +44,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
  "fastrace",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -351,7 +351,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ checksum = "003d767f357cf1f04a444766b2646682a75732505d71553d02f81c6848e0533e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -808,7 +808,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -903,7 +903,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1102,7 +1102,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1154,6 +1154,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1245,7 +1256,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1273,7 +1284,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1437,7 +1448,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1547,7 +1558,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -1670,7 +1681,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1686,7 +1697,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1745,7 +1756,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/crates/fastrace-macro/Cargo.toml
+++ b/crates/fastrace-macro/Cargo.toml
@@ -22,7 +22,7 @@ enable = []
 [dependencies]
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.45" }
-syn = { version = "2.0.118", features = [
+syn = { version = "3.0.3", features = [
   "full",
   "parsing",
   "extra-traits",

--- a/crates/fastrace-macro/src/impls.rs
+++ b/crates/fastrace-macro/src/impls.rs
@@ -90,7 +90,7 @@ pub(crate) fn gen_trace(args: Args, input: ItemFn) -> Result<TokenStream> {
     let Signature {
         output: return_type,
         inputs: params,
-        unsafety,
+        safety,
         constness,
         abi,
         ident,
@@ -107,7 +107,7 @@ pub(crate) fn gen_trace(args: Args, input: ItemFn) -> Result<TokenStream> {
     let fn_span = ident.span();
     Ok(quote_spanned!(fn_span=>
         #(#attrs) *
-        #vis #constness #unsafety #asyncness #abi fn #ident<#gen_params>(#params) #return_type
+        #vis #constness #safety #asyncness #abi fn #ident<#gen_params>(#params) #return_type
         #where_clause
         {
             #func_body
@@ -195,6 +195,7 @@ fn gen_block(
             fn visit_type_mut(&mut self, ty: &mut Type) {
                 if let Type::ImplTrait(..) = ty {
                     *ty = Type::Infer(TypeInfer {
+                        attrs: Vec::new(),
                         underscore_token: Token![_](ty.span()),
                     });
                 } else {


### PR DESCRIPTION
## Summary

- upgrade the fastrace-macro direct dependency from syn 2.0.118 to 3.0.3
- adapt function signature handling to the syn 3 Safety API
- initialize the new TypeInfer attrs field while preserving the original underscore span

## Testing

- cargo +nightly fmt --all -- --check
- cargo +nightly clippy --all-targets --all-features -- --deny warnings
- cargo +nightly clippy in examples and benches
- cargo build --workspace --all-features --all-targets
- cargo nextest run --workspace (67 passed)
- cargo test --doc